### PR TITLE
Implement tokenization

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,4 @@
-import { tokenize as tokenizerTokenize } from './src/tokenizer/tokenizer'
-import { TokenStream } from './src/tokenizer/token-stream'
-
-export function tokenize (input: string): TokenStream {
-  return tokenizerTokenize(input)
-}
+export { tokenize } from './src/tokenizer/tokenizer'
 
 export function parse (input: string): any {
 }

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,9 @@
-export function parse (input: String): any {
+import { tokenize as tokenizerTokenize } from './src/tokenizer/tokenizer'
+import { TokenStream } from './src/tokenizer/token-stream'
+
+export function tokenize (input: string): TokenStream {
+  return tokenizerTokenize(input)
+}
+
+export function parse (input: string): any {
 }

--- a/src/tokenizer/errors.ts
+++ b/src/tokenizer/errors.ts
@@ -1,6 +1,15 @@
 import { Token, TokenType } from './token'
 
 /**
+ * Thrown when an input is given for which a token type cannot be determined.
+ */
+export class UnknownTokenTypeError extends Error {
+  constructor () {
+    super('unable to determine token type')
+  }
+}
+
+/**
  * Thrown when a string token is detected, but there is no closing quote.
  */
 export class UnterminatedStringError extends Error {

--- a/src/tokenizer/errors.ts
+++ b/src/tokenizer/errors.ts
@@ -1,0 +1,47 @@
+import { Token, TokenType } from './token'
+
+/**
+ * Thrown when a string token is detected, but there is no closing quote.
+ */
+export class UnterminatedStringError extends Error {
+  constructor () {
+    super('unterminated string')
+  }
+}
+
+/**
+ * Thrown when another token is requested from the stream, but no more tokens exist.
+ */
+export class EndOfStreamError extends Error {
+  constructor () {
+    super('end of stream reached')
+  }
+}
+
+/**
+ * Thrown when a token of a different type was requested than is currently present in the stream.
+ */
+export class UnexpectedTokenTypeError extends Error {
+  readonly actual: Token
+  readonly expectedType: TokenType
+
+  constructor (actual: Token, expectedType: TokenType) {
+    super(`unexpected token <${actual.type}>, expected <${expectedType}>`)
+    this.actual = actual
+    this.expectedType = expectedType
+  }
+}
+
+/**
+ * Thrown when a token with a different value was requested than is currently present in the stream.
+ */
+export class UnexpectedTokenValueError extends Error {
+  readonly actual: Token
+  readonly expectedValue: string
+
+  constructor (actual: Token, expectedValue: string) {
+    super(`unexpected token value '${actual.value}', expected '${expectedValue}'`)
+    this.actual = actual
+    this.expectedValue = expectedValue
+  }
+}

--- a/src/tokenizer/token-stream.ts
+++ b/src/tokenizer/token-stream.ts
@@ -1,0 +1,77 @@
+import { Token, TokenType } from './token'
+import { EndOfStreamError, UnexpectedTokenTypeError, UnexpectedTokenValueError } from './errors'
+
+/**
+ * A stream of tokens that allows for sequential processing.
+ * This keeps an internal pointer that is advanced to the next token every time a token is popped off.
+ * It also supports peeking at the next token without popping it off.
+ */
+export class TokenStream {
+  private readonly tokens: Token[]
+  private nextPointer: number = 0
+
+  constructor (tokens: Token[]) {
+    this.tokens = tokens
+  }
+
+  /**
+   * Check stream state.
+   *
+   * @returns {boolean} Whether there are any more tokens left.
+   */
+  hasNext (): boolean {
+    return this.nextPointer < this.tokens.length
+  }
+
+  /**
+   * Obtain the next token without advancing the stream.
+   *
+   * @returns {Token} The next token in the stream.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   */
+  peek (): Token {
+    if (!this.hasNext()) {
+      throw new EndOfStreamError()
+    }
+    return this.tokens[this.nextPointer]
+  }
+
+  /**
+   * Obtain the next token and advance the stream, but only if the token matches the given type.
+   * If the type does not match, this returns undefined and the stream does not change state.
+   *
+   * @param {TokenType} type The type of token to pop off.
+   * @returns {Token | undefined} The next token in the stream, or undefined.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   */
+  popOptional (type: TokenType): Token | undefined {
+    const token = this.peek()
+    if (token.type !== type) {
+      return undefined
+    }
+    ++this.nextPointer
+    return token
+  }
+
+  /**
+   * Obtain the next token and advance the stream. The token must be of the given type,
+   * otherwise an error will be thrown. Optionally, the token value can be asserted in the same manner.
+   *
+   * @param {TokenType} type The type of token to pop off.
+   * @param {?string} value The value the token is expected to have.
+   * @returns {Token} The next token in the stream.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   * @throws {UnexpectedTokenTypeError} If the token type mismatches.
+   * @throws {UnexpectedTokenValueError} If a token value was specified, and it mismatches.
+   */
+  pop (type: TokenType, value?: string): Token {
+    const optToken = this.popOptional(type)
+    if (optToken == null) {
+      throw new UnexpectedTokenTypeError(this.peek(), type)
+    }
+    if (value != null && optToken.value !== value) {
+      throw new UnexpectedTokenValueError(optToken, value)
+    }
+    return optToken
+  }
+}

--- a/src/tokenizer/token.ts
+++ b/src/tokenizer/token.ts
@@ -1,0 +1,24 @@
+export enum TokenType {
+  WORD = 'word',
+  EQUALS = 'equals',
+  COLON = 'colon',
+  PAREN_LEFT = 'paren_left',
+  PAREN_RIGHT = 'paren_right',
+  BLOCK_LEFT = 'block_left',
+  BLOCK_RIGHT = 'block_right',
+  ARROW = 'arrow',
+  STRING = 'string'
+}
+
+/**
+ * A single token, split from an input string.
+ */
+export class Token {
+  readonly type: TokenType
+  readonly value: string
+
+  constructor (type: TokenType, value: string) {
+    this.type = type
+    this.value = value
+  }
+}

--- a/src/tokenizer/tokenizer.ts
+++ b/src/tokenizer/tokenizer.ts
@@ -1,31 +1,54 @@
 import { Token, TokenType } from './token'
 import { TokenStream } from './token-stream'
-import { UnterminatedStringError } from './errors'
+import { UnknownTokenTypeError, UnterminatedStringError } from './errors'
 import { regexpIndexOf } from '../util/regexp-index-of'
 
 /**
- * Match the next token form the input string, starting at the given position.
+ * This record stores the values of each of the fixed token types.
+ */
+const FIXED_TYPES: Readonly<Record<string, TokenType>> = {
+  '=': TokenType.EQUALS,
+  '(': TokenType.PAREN_LEFT,
+  ')': TokenType.PAREN_RIGHT,
+  '{': TokenType.BLOCK_LEFT,
+  '}': TokenType.BLOCK_RIGHT,
+  ':': TokenType.COLON,
+  '->': TokenType.ARROW
+}
+
+/**
+ * This RegExp matches the start of another token or whitespace.
+ * This is useful in determining when a token ends.
+ */
+const TOKEN_END_REGEXP = /[\s=(){}:"]|->/
+
+/**
+ * Try matching the input against the fixed token types.
+ * A token type is considered "fixed" if its tokens can only ever have one specific value.
  *
  * @param {string} str The input.
  * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token} The matched token.
- * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
  */
-function matchToken (str: string, start: number): Token {
-  const singleCharTokens: Record<string, TokenType> = {
-    '=': TokenType.EQUALS,
-    '(': TokenType.PAREN_LEFT,
-    ')': TokenType.PAREN_RIGHT,
-    '{': TokenType.BLOCK_LEFT,
-    '}': TokenType.BLOCK_RIGHT,
-    ':': TokenType.COLON
+function tryMatchFixed (str: string, start: number): Token | undefined {
+  for (const fixed of Object.keys(FIXED_TYPES)) {
+    if (str.indexOf(fixed, start) === start) {
+      return new Token(FIXED_TYPES[fixed], fixed)
+    }
   }
-  if (singleCharTokens[str[start]] != null) {
-    return new Token(singleCharTokens[str[start]], str[start])
-  }
-  if (str.indexOf('->', start) === start) {
-    return new Token(TokenType.ARROW, str.slice(start, start + 2))
-  }
+  return undefined
+}
+
+/**
+ * Try matching the input as a string.
+ * Anything is considered a string that starts with a quotation mark.
+ *
+ * @param {string} str The input.
+ * @param {number} start The current position in the input string (start of the token to match).
+ * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
+ * @throws {UnterminatedStringError} If the matched string is left unterminated.
+ */
+function tryMatchString (str: string, start: number): Token | undefined {
   if (str[start] === '"') {
     const closing = str.indexOf('"', start + 1)
     if (closing < 0) {
@@ -33,7 +56,19 @@ function matchToken (str: string, start: number): Token {
     }
     return new Token(TokenType.STRING, str.slice(start, closing + 1))
   }
-  let end = regexpIndexOf(str, /[\s=(){}:"]|->/, start)
+  return undefined
+}
+
+/**
+ * Try matching the input as a word.
+ * A word is any sequence of regular characters up until the next whitespace, string token, or fixed token.
+ *
+ * @param {string} str The input.
+ * @param {number} start The current position in the input string (start of the token to match).
+ * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
+ */
+function tryMatchWord (str: string, start: number): Token | undefined {
+  let end = regexpIndexOf(str, TOKEN_END_REGEXP, start)
   if (end < 0) {
     end = str.length
   }
@@ -41,11 +76,33 @@ function matchToken (str: string, start: number): Token {
 }
 
 /**
+ * Match the next token form the input string, starting at the given position.
+ *
+ * @param {string} str The input.
+ * @param {number} start The current position in the input string (start of the token to match).
+ * @returns {Token} The matched token.
+ * @throws {UnknownTokenTypeError} If the type of token could not be determined.
+ * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ */
+function matchToken (str: string, start: number): Token {
+  const match = tryMatchFixed(str, start) ??
+    tryMatchString(str, start) ??
+    tryMatchWord(str, start)
+
+  if (match == null) {
+    throw new UnknownTokenTypeError()
+  }
+
+  return match
+}
+
+/**
  * Convert the given string into a stream of tokens.
  *
  * @param {string} str The input.
  * @returns {TokenStream} The tokenize result.
- * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ * @throws {UnknownTokenTypeError} If the string includes a token whose type cannot be determined.
+ * @throws {UnterminatedStringError} If the string includes a token that is left unterminated.
  */
 export function tokenize (str: string): TokenStream {
   const tokens: Token[] = []

--- a/src/tokenizer/tokenizer.ts
+++ b/src/tokenizer/tokenizer.ts
@@ -1,0 +1,64 @@
+import { Token, TokenType } from './token'
+import { TokenStream } from './token-stream'
+import { UnterminatedStringError } from './errors'
+import { regexpIndexOf } from '../util/regexp-index-of'
+
+/**
+ * Match the next token form the input string, starting at the given position.
+ *
+ * @param {string} str The input.
+ * @param {number} start The current position in the input string (start of the token to match).
+ * @returns {Token} The matched token.
+ * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ */
+function matchToken (str: string, start: number): Token {
+  const singleCharTokens: Record<string, TokenType> = {
+    '=': TokenType.EQUALS,
+    '(': TokenType.PAREN_LEFT,
+    ')': TokenType.PAREN_RIGHT,
+    '{': TokenType.BLOCK_LEFT,
+    '}': TokenType.BLOCK_RIGHT,
+    ':': TokenType.COLON
+  }
+  if (singleCharTokens[str[start]] != null) {
+    return new Token(singleCharTokens[str[start]], str[start])
+  }
+  if (str.indexOf('->', start) === start) {
+    return new Token(TokenType.ARROW, str.slice(start, start + 2))
+  }
+  if (str[start] === '"') {
+    const closing = str.indexOf('"', start + 1)
+    if (closing < 0) {
+      throw new UnterminatedStringError()
+    }
+    return new Token(TokenType.STRING, str.slice(start, closing + 1))
+  }
+  let end = regexpIndexOf(str, /[\s=(){}:"]|->/, start)
+  if (end < 0) {
+    end = str.length
+  }
+  return new Token(TokenType.WORD, str.slice(start, end))
+}
+
+/**
+ * Convert the given string into a stream of tokens.
+ *
+ * @param {string} str The input.
+ * @returns {TokenStream} The tokenize result.
+ * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ */
+export function tokenize (str: string): TokenStream {
+  const tokens: Token[] = []
+
+  for (let i = 0; i < str.length;) {
+    if (/\s/.test(str[i])) {
+      ++i
+      continue
+    }
+    const token = matchToken(str, i)
+    tokens.push(token)
+    i += token.value.length
+  }
+
+  return new TokenStream(tokens)
+}

--- a/src/util/regexp-index-of.ts
+++ b/src/util/regexp-index-of.ts
@@ -1,0 +1,19 @@
+/**
+ * Like String.prototype.indexOf(), but with a regular expression.
+ * I.e. find the first matching index of the given RegExp, with the possibility to define a starting index.
+ *
+ * @param {string} str The subject.
+ * @param {RegExp} regexp The regular expression to search for.
+ * @param {?number} position Optionally, a start index.
+ * @returns {number} The position at which the RegExp first matched, or -1 if no match was found.
+ */
+export function regexpIndexOf (str: string, regexp: RegExp, position?: number): number {
+  if (position == null || position === 0) {
+    return str.search(regexp)
+  }
+  const subIndex = str.slice(position).search(regexp)
+  if (subIndex < 0) {
+    return subIndex
+  }
+  return position + subIndex
+}

--- a/src/util/regexp-index-of.ts
+++ b/src/util/regexp-index-of.ts
@@ -8,12 +8,15 @@
  * @returns {number} The position at which the RegExp first matched, or -1 if no match was found.
  */
 export function regexpIndexOf (str: string, regexp: RegExp, position?: number): number {
-  if (position == null || position === 0) {
+  // string.indexOf() treats positions < 0 as equal to 0
+  if (position == null || position <= 0) {
     return str.search(regexp)
   }
-  const subIndex = str.slice(position).search(regexp)
+  // string.indexOf() treats positions greater than str.length as equal to str.length
+  const offset = Math.min(offset, str.length)
+  const subIndex = str.slice(offset).search(regexp)
   if (subIndex < 0) {
     return subIndex
   }
-  return position + subIndex
+  return offset + subIndex
 }

--- a/src/util/regexp-index-of.ts
+++ b/src/util/regexp-index-of.ts
@@ -13,7 +13,7 @@ export function regexpIndexOf (str: string, regexp: RegExp, position?: number): 
     return str.search(regexp)
   }
   // string.indexOf() treats positions greater than str.length as equal to str.length
-  const offset = Math.min(offset, str.length)
+  const offset = Math.min(position, str.length)
   const subIndex = str.slice(offset).search(regexp)
   if (subIndex < 0) {
     return subIndex

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,24 @@
 import * as index from '../index'
 
 import { expect } from 'chai'
+import { TokenStream } from '../src/tokenizer/token-stream'
+import { TokenType } from '../src/tokenizer/token'
 
 describe('index.ts', function () {
+  describe('#tokenize()', function () {
+    it('is a function', function () {
+      expect(index.tokenize).to.be.a('function')
+    })
+
+    it('performs tokenization', function () {
+      const result = index.tokenize('foo : "bar"')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.WORD).value).to.equal('foo')
+      expect(result.pop(TokenType.COLON).value).to.equal(':')
+      expect(result.pop(TokenType.STRING).value).to.equal('"bar"')
+    })
+  })
+
   describe('#parse()', function () {
     it('is a function', function () {
       expect(index.parse).to.be.a('function')

--- a/test/tokenizer/token-stream.test.ts
+++ b/test/tokenizer/token-stream.test.ts
@@ -1,0 +1,132 @@
+import { TokenStream } from '../../src/tokenizer/token-stream'
+import { Token, TokenType } from '../../src/tokenizer/token'
+import { UnexpectedTokenTypeError, UnexpectedTokenValueError } from '../../src/tokenizer/errors'
+
+import { expect } from 'chai'
+
+describe('src/tokenizer/token-stream.ts', function () {
+  describe('#hasNext()', function () {
+    it('returns false for empty stream', function () {
+      expect(new TokenStream([]).hasNext()).to.be.false
+    })
+
+    it('returns true for non-empty stream', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).hasNext()).to.be.true
+    })
+  })
+
+  describe('#peek()', function () {
+    it('throws an error if called on empty stream', function () {
+      expect(() => new TokenStream([]).peek()).to.throw()
+    })
+
+    it('returns first token', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).peek()).to.equal(tokens[0])
+    })
+
+    it('does not advance the stream', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      const obj = new TokenStream(tokens)
+      expect(obj.peek()).to.equal(obj.peek())
+      expect(obj.hasNext()).to.be.true
+    })
+  })
+
+  describe('#popOptional()', function () {
+    it('throws an error if called on empty stream', function () {
+      expect(() => new TokenStream([]).popOptional(TokenType.WORD)).to.throw()
+    })
+
+    it('returns token if type matches', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).popOptional(TokenType.WORD)).to.equal(tokens[0])
+    })
+
+    it('returns undefined if type does not match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).popOptional(TokenType.PAREN_LEFT)).to.be.undefined
+    })
+
+    it('advances the stream, but only on a match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      stream.popOptional(TokenType.PAREN_LEFT)
+      expect(stream.hasNext()).to.be.true
+      stream.popOptional(TokenType.WORD)
+      expect(stream.hasNext()).to.be.false
+    })
+
+    it('works multiple times in a row', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test'),
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.PAREN_RIGHT, '(')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(stream.popOptional(TokenType.WORD)).to.equal(tokens[0])
+      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(stream.popOptional(TokenType.PAREN_LEFT)).to.equal(tokens[1])
+      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(stream.popOptional(TokenType.PAREN_RIGHT)).to.equal(tokens[2])
+      expect(stream.hasNext()).to.be.false
+    })
+  })
+
+  describe('#pop()', function () {
+    it('throws an error if called on empty stream', function () {
+      expect(() => new TokenStream([]).pop(TokenType.WORD)).to.throw()
+    })
+
+    it('returns token if type matches', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).pop(TokenType.WORD)).to.equal(tokens[0])
+    })
+
+    it('returns token if type and value match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(new TokenStream(tokens).pop(TokenType.WORD, 'test')).to.equal(tokens[0])
+    })
+
+    it('throws if type does not match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(() => new TokenStream(tokens).pop(TokenType.PAREN_LEFT)).to.throw(UnexpectedTokenTypeError)
+    })
+
+    it('throws if type matches, but value does not', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      expect(() => new TokenStream(tokens).pop(TokenType.WORD, 'foo')).to.throw(UnexpectedTokenValueError)
+    })
+
+    it('advances the stream on a match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      stream.pop(TokenType.WORD)
+      expect(stream.hasNext()).to.be.false
+    })
+  })
+})

--- a/test/tokenizer/tokenizer.test.ts
+++ b/test/tokenizer/tokenizer.test.ts
@@ -1,0 +1,82 @@
+import { tokenize } from '../../src/tokenizer/tokenizer'
+import { TokenStream } from '../../src/tokenizer/token-stream'
+import { TokenType } from '../../src/tokenizer/token'
+import { UnterminatedStringError } from '../../src/tokenizer/errors'
+
+import { expect } from 'chai'
+
+describe('src/tokenizer/tokenizer.ts', function () {
+  describe('tokenize()', function () {
+    it('returns empty stream for empty input', function () {
+      const result = tokenize('')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('returns empty stream for whitespace', function () {
+      const result = tokenize('   \n   ')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('detects all token types correctly if placed in sequence', function () {
+      const result = tokenize('= ( ) { } : foo "bar baz" word$with.special*chars')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.EQUALS).value).to.equal('=')
+      expect(result.pop(TokenType.PAREN_LEFT).value).to.equal('(')
+      expect(result.pop(TokenType.PAREN_RIGHT).value).to.equal(')')
+      expect(result.pop(TokenType.BLOCK_LEFT).value).to.equal('{')
+      expect(result.pop(TokenType.BLOCK_RIGHT).value).to.equal('}')
+      expect(result.pop(TokenType.COLON).value).to.equal(':')
+      expect(result.pop(TokenType.WORD).value).to.equal('foo')
+      expect(result.pop(TokenType.STRING).value).to.equal('"bar baz"')
+      expect(result.pop(TokenType.WORD).value).to.equal('word$with.special*chars')
+    })
+
+    it('detects strings', function () {
+      const result = tokenize('"foo bar" "baz" "key:value" "call()"')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.STRING).value).to.equal('"foo bar"')
+      expect(result.pop(TokenType.STRING).value).to.equal('"baz"')
+      expect(result.pop(TokenType.STRING).value).to.equal('"key:value"')
+      expect(result.pop(TokenType.STRING).value).to.equal('"call()"')
+    })
+
+    it('detects words', function () {
+      const result = tokenize('foo foo_bar b*z')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.WORD).value).to.equal('foo')
+      expect(result.pop(TokenType.WORD).value).to.equal('foo_bar')
+      expect(result.pop(TokenType.WORD).value).to.equal('b*z')
+    })
+
+    it('detects strings directly following other tokens', function () {
+      const result = tokenize('("bar1" foo"bar2" "foo""bar3"')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      result.pop(TokenType.PAREN_LEFT)
+      expect(result.pop(TokenType.STRING).value).to.equal('"bar1"')
+      result.pop(TokenType.WORD)
+      expect(result.pop(TokenType.STRING).value).to.equal('"bar2"')
+      result.pop(TokenType.STRING)
+      expect(result.pop(TokenType.STRING).value).to.equal('"bar3"')
+    })
+
+    it('throws for unterminated strings', function () {
+      expect(() => tokenize('"string" "unterminated string')).to.throw(UnterminatedStringError)
+    })
+
+    it('detects arrows', function () {
+      const result = tokenize('->')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.ARROW).value).to.equal('->')
+    })
+
+    it('detects arrows between words', function () {
+      const result = tokenize('foo->bar')
+      expect(result).to.be.an.instanceOf(TokenStream)
+      expect(result.pop(TokenType.WORD).value).to.equal('foo')
+      expect(result.pop(TokenType.ARROW).value).to.equal('->')
+      expect(result.pop(TokenType.WORD).value).to.equal('bar')
+    })
+  })
+})

--- a/test/util/regexp-index-of.test.ts
+++ b/test/util/regexp-index-of.test.ts
@@ -34,4 +34,19 @@ describe('src/util/regexp-index-of.ts', function () {
       expect(regexpIndexOf('hello world', /\s+/, 7)).to.equal(-1)
     })
   })
+
+  describe('regexpIndexOf() with out-of-bounds positions', function () {
+    it('treats negative positions like 0', function () {
+      expect(regexpIndexOf('hello world', /h/, -3)).to.equal(0)
+      expect(regexpIndexOf('hello world', /world/, -3)).to.equal(6)
+      expect(regexpIndexOf('hello world', /./, -3)).to.equal(0)
+      expect(regexpIndexOf('hello world', /\s+/, -3)).to.equal(5)
+    })
+
+    it('treats too large positions like string.length', function () {
+      expect(regexpIndexOf('hello world', /x/, 100)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /\s*/, 100)).to.equal(11)
+      expect(regexpIndexOf('hello world', /h/, 100)).to.equal(-1)
+    })
+  })
 })

--- a/test/util/regexp-index-of.test.ts
+++ b/test/util/regexp-index-of.test.ts
@@ -1,0 +1,37 @@
+import { regexpIndexOf } from '../../src/util/regexp-index-of'
+
+import { expect } from 'chai'
+
+describe('src/util/regexp-index-of.ts', function () {
+  describe('regexpIndexOf() without position', function () {
+    it('returns position of first match, if it exists', function () {
+      expect(regexpIndexOf('hello world', /h/)).to.equal(0)
+      expect(regexpIndexOf('hello world', /world/)).to.equal(6)
+      expect(regexpIndexOf('hello world', /./)).to.equal(0)
+      expect(regexpIndexOf('hello world', /\s+/)).to.equal(5)
+    })
+
+    it('returns -1 if RegExp does not match', function () {
+      expect(regexpIndexOf('hello world', /x/)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /\s{2,}/)).to.equal(-1)
+    })
+  })
+
+  describe('regexpIndexOf() with position', function () {
+    it('returns position of first match, if it exists', function () {
+      expect(regexpIndexOf('hello world', /h/, 0)).to.equal(0)
+      expect(regexpIndexOf('hello world', /world/, 6)).to.equal(6)
+      expect(regexpIndexOf('hello world', /./, 3)).to.equal(3)
+      expect(regexpIndexOf('hello world', /\s+/, 1)).to.equal(5)
+    })
+
+    it('returns -1 if RegExp does not match', function () {
+      expect(regexpIndexOf('hello world', /x/)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /\s{2,}/)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /h/, 1)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /world/, 8)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /./, 11)).to.equal(-1)
+      expect(regexpIndexOf('hello world', /\s+/, 7)).to.equal(-1)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds tokenization. Tokenization is the process of converting an input string into separate strings that each have an associated token type, i.e. `STRING` or `PAREN_LEFT` etc.

The input is converted into a `TokenStream` that enables sequential processing of the found tokens, with strict token-type and token-value assertions.

Tests are implemented for each of the modules.