### PR TITLE
Implement parser for object definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,23 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/38ab87695968c1832c45/test_coverage)](https://codeclimate.com/github/meyfa/lifeline/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/38ab87695968c1832c45/maintainability)](https://codeclimate.com/github/meyfa/lifeline/maintainability)
 
-A textual language that compiles to UML sequence diagrams.
+**Lifeline** is a textual language that compiles to UML sequence diagrams.
+
+
+## Syntax
+
+Every Lifeline script consists of an Object Definition Section followed by a
+Message Section.
+There can be many object definitions and many messages.
+
+### Object Definitions
+
+Objects can be defined as follows:
+
+```
+object foo = "Foo"
+object(actor) bar = "Bar"
+```
+
+This will create one _component object_ with id `foo` and label `Foo`,
+as well as one _actor object_ with id `bar` and label `Bar`.

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,11 @@
-export { tokenize } from './src/tokenizer/tokenizer'
+import { Sequence } from './src/sequence/sequence'
+import { tokenize } from './src/tokenizer/tokenizer'
+import { parse } from './src/parser/parser'
 
-export function parse (input: string): any {
+export { tokenize } from './src/tokenizer/tokenizer'
+export { parse } from './src/parser/parser'
+
+export function compileToSequence (input: string): Sequence {
+  const tokens = tokenize(input)
+  return parse(tokens)
 }

--- a/src/parser/entity/entity-options.ts
+++ b/src/parser/entity/entity-options.ts
@@ -1,0 +1,13 @@
+/**
+ * This describes the complete set of options available when declaring an entity.
+ */
+export interface EntityOptions {
+  isActor: boolean
+}
+
+/**
+ * These are the default options for entity definitions, which can be changed individually depending on input.
+ */
+export const defaultEntityOptions: Readonly<EntityOptions> = {
+  isActor: false
+}

--- a/src/parser/entity/parse-entity-options.ts
+++ b/src/parser/entity/parse-entity-options.ts
@@ -1,0 +1,51 @@
+import { TokenStream } from '../../tokenizer/token-stream'
+import { Token, TokenType } from '../../tokenizer/token'
+import { DuplicateOptionError, UnsupportedOptionError } from '../errors'
+import { entityOptions } from '../strings'
+import { defaultEntityOptions, EntityOptions } from './entity-options'
+
+function applyOption (option: string, obj: EntityOptions): void {
+  if (option === entityOptions.actor) {
+    obj.isActor = true
+    return
+  }
+  throw new UnsupportedOptionError(option, [entityOptions.actor])
+}
+
+function getOptions (tokens: TokenStream): EntityOptions {
+  const set = new Set<string>()
+  const options: EntityOptions = { ...defaultEntityOptions }
+  for (let option; (option = tokens.popOptional(TokenType.WORD)?.value) != null;) {
+    if (set.has(option)) {
+      throw new DuplicateOptionError(option)
+    }
+    applyOption(option, options)
+    set.add(option)
+  }
+  return options
+}
+
+/**
+ * Determine whether the given token marks the beginning of entity options.
+ * This will only produce valid results for tokens at the correct position within entity definitions.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token could be parsed as entity options.
+ */
+export function detectEntityOptions (token: Token): boolean {
+  return token.type === TokenType.PAREN_LEFT
+}
+
+/**
+ * Force-parse entity options from the given stream.
+ *
+ * @param {TokenStream} tokens The input stream.
+ * @returns {EntityOptions} The parsed options.
+ */
+export function parseEntityOptions (tokens: TokenStream): EntityOptions {
+  tokens.pop(TokenType.PAREN_LEFT)
+  const options = getOptions(tokens)
+  tokens.pop(TokenType.PAREN_RIGHT)
+
+  return options
+}

--- a/src/parser/entity/parse-entity.ts
+++ b/src/parser/entity/parse-entity.ts
@@ -1,0 +1,40 @@
+import { TokenStream } from '../../tokenizer/token-stream'
+import { Entity, EntityType } from '../../sequence/entity'
+import { Token, TokenType } from '../../tokenizer/token'
+import { unquote } from '../unquote'
+import { detectEntityOptions, parseEntityOptions } from './parse-entity-options'
+import { keywords } from '../strings'
+import { defaultEntityOptions } from './entity-options'
+
+/**
+ * Determine whether the given token marks the beginning of an entity definition.
+ * This will only produce valid results for tokens at global scope.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token could be parsed as an entity definition.
+ */
+export function detectEntity (token: Token): boolean {
+  return token.type === TokenType.WORD && token.value === keywords.object
+}
+
+/**
+ * Force-parse an entity definition from the given stream.
+ *
+ * @param {TokenStream} tokens The input stream.
+ * @returns {Entity} The parsed entity.
+ */
+export function parseEntity (tokens: TokenStream): Entity {
+  tokens.pop(TokenType.WORD, keywords.object)
+
+  const options = detectEntityOptions(tokens.peek())
+    ? parseEntityOptions(tokens)
+    : defaultEntityOptions
+
+  const type = options.isActor ? EntityType.ACTOR : EntityType.COMPONENT
+
+  const id = tokens.pop(TokenType.WORD).value
+  tokens.pop(TokenType.EQUALS)
+  const displayName = unquote(tokens.pop(TokenType.STRING))
+
+  return new Entity(type, id, displayName)
+}

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,0 +1,19 @@
+import { Token } from '../tokenizer/token'
+
+export class UnexpectedTokenError extends Error {
+  constructor (token: Token) {
+    super(`unexpected token <${token.type}> '${token.value}'`)
+  }
+}
+
+export class UnsupportedOptionError extends Error {
+  constructor (option: string, supported: string[]) {
+    super(`unsupported option ${option}, valid options are: ${supported.join(', ')}`)
+  }
+}
+
+export class DuplicateOptionError extends Error {
+  constructor (option: string) {
+    super(`duplicate option ${option}`)
+  }
+}

--- a/src/parser/parser-state.ts
+++ b/src/parser/parser-state.ts
@@ -1,0 +1,74 @@
+import { Entity } from '../sequence/entity'
+import { Activation } from '../sequence/activation'
+
+/**
+ * This interface enables looking up an Entity by its id.
+ */
+export interface EntityLookup {
+  /**
+   * Obtain the entity with the given id, if it exists.
+   *
+   * @param {string} id The entity id.
+   * @returns {Entity|undefined} The lookup result.
+   */
+  lookupEntity: (id: string) => Entity | undefined
+}
+
+/**
+ * This class implements an imperative view on parser state.
+ * It allows for inserting entities and looking them up again, as well as inserting activations.
+ */
+export class ParserState implements EntityLookup {
+  private readonly entities: Entity[] = []
+  private readonly entityMap: Map<string, Entity> = new Map()
+
+  private readonly rootActivations: Activation[] = []
+
+  /**
+   * Add the given entity to this state.
+   *
+   * @param {Entity} entity The entity.
+   * @returns {void}
+   */
+  insertEntity (entity: Entity): void {
+    if (this.entityMap.has(entity.id)) {
+      throw new Error(`duplicate entity id: "${entity.id}"`)
+    }
+    this.entities.push(entity)
+    this.entityMap.set(entity.id, entity)
+  }
+
+  /**
+   * Add the given activation to this state. The activation must be a top-level activation,
+   * in other words, child activations should not be added with this.
+   *
+   * @param {Activation} activation The activation.
+   * @returns {void}
+   */
+  insertActivation (activation: Activation): void {
+    this.rootActivations.push(activation)
+  }
+
+  /**
+   * Retrieve all entities currently added to this state object.
+   *
+   * @returns {Entity[]} The entities.
+   */
+  getEntities (): Entity[] {
+    return this.entities
+  }
+
+  /**
+   * Retrieve all activations currently added to this state object.
+   * This does not consider child activations, but gives a flat view of just the root activations.
+   *
+   * @returns {Activation[]} The activations.
+   */
+  getRootActivations (): Activation[] {
+    return this.rootActivations
+  }
+
+  lookupEntity (id: string): Entity | undefined {
+    return this.entityMap.get(id)
+  }
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,0 +1,28 @@
+import { TokenStream } from '../tokenizer/token-stream'
+import { Sequence } from '../sequence/sequence'
+import { ParserState } from './parser-state'
+import { UnexpectedTokenError } from './errors'
+import { detectEntity, parseEntity } from './entity/parse-entity'
+
+/**
+ * Parse the given stream of tokens into a sequence.
+ * This expects the stream to contain a completely valid document, otherwise an error will be thrown when there
+ * is a token mismatch.
+ *
+ * @param {TokenStream} tokens The input token stream as produced by the tokenizer.
+ * @returns {Sequence} The parsed sequence.
+ */
+export function parse (tokens: TokenStream): Sequence {
+  const state = new ParserState()
+
+  while (tokens.hasNext()) {
+    const token = tokens.peek()
+    if (detectEntity(token)) {
+      state.insertEntity(parseEntity(tokens))
+      continue
+    }
+    throw new UnexpectedTokenError(token)
+  }
+
+  return new Sequence(state.getEntities(), state.getRootActivations())
+}

--- a/src/parser/strings.ts
+++ b/src/parser/strings.ts
@@ -1,0 +1,14 @@
+/**
+ * All general keywords used in the parser.
+ */
+export const keywords = {
+  object: 'object',
+  outside: '*'
+}
+
+/**
+ * Available options when defining entities.
+ */
+export const entityOptions = {
+  actor: 'actor'
+}

--- a/src/parser/unquote.ts
+++ b/src/parser/unquote.ts
@@ -1,0 +1,14 @@
+import { Token, TokenType } from '../tokenizer/token'
+
+/**
+ * Unquote the given string token, returning its true value.
+ *
+ * @param {string} stringToken The token, which must have type STRING.
+ * @returns {string} The unquoted value.
+ */
+export function unquote (stringToken: Token): string {
+  if (stringToken.type !== TokenType.STRING) {
+    throw new Error('expected string')
+  }
+  return stringToken.value.slice(1, stringToken.value.length - 1)
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,8 @@
 import * as index from '../index'
+import { TokenStream } from '../src/tokenizer/token-stream'
+import { Token, TokenType } from '../src/tokenizer/token'
 
 import { expect } from 'chai'
-import { TokenStream } from '../src/tokenizer/token-stream'
-import { TokenType } from '../src/tokenizer/token'
 
 describe('index.ts', function () {
   describe('#tokenize()', function () {
@@ -22,6 +22,33 @@ describe('index.ts', function () {
   describe('#parse()', function () {
     it('is a function', function () {
       expect(index.parse).to.be.a('function')
+    })
+
+    it('performs parsing', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.WORD, 'object'),
+        new Token(TokenType.WORD, 'foo'),
+        new Token(TokenType.EQUALS, '='),
+        new Token(TokenType.STRING, '"bar"')
+      ])
+
+      const result = index.parse(tokens)
+      expect(result.entities.length).to.equal(1)
+      expect(result.entities[0].id).to.equal('foo')
+      expect(result.entities[0].name).to.equal('bar')
+    })
+  })
+
+  describe('#compileToSequence()', function () {
+    it('is a function', function () {
+      expect(index.compileToSequence).to.be.a('function')
+    })
+
+    it('tokenizes and parses', function () {
+      const result = index.compileToSequence('object foo = "bar"')
+      expect(result.entities.length).to.equal(1)
+      expect(result.entities[0].id).to.equal('foo')
+      expect(result.entities[0].name).to.equal('bar')
     })
   })
 })

--- a/test/parser/entity/parse-entity-options.test.ts
+++ b/test/parser/entity/parse-entity-options.test.ts
@@ -1,0 +1,49 @@
+import { detectEntityOptions, parseEntityOptions } from '../../../src/parser/entity/parse-entity-options'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+
+import { expect } from 'chai'
+
+describe('src/parser/entity/parse-entity-options.ts', function () {
+  describe('detectEntityOptions()', function () {
+    it('returns true if given left paren', function () {
+      const token = new Token(TokenType.PAREN_LEFT, '(')
+      expect(detectEntityOptions(token)).to.be.true
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.WORD, 'foo')
+      expect(detectEntityOptions(token)).to.be.false
+    })
+  })
+
+  describe('parseEntityOptions()', function () {
+    it('returns defaults for empty options', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.PAREN_RIGHT, ')')
+      ])
+      const parsed = parseEntityOptions(tokens)
+      expect(parsed.isActor).to.be.false
+    })
+
+    it('parses actor option', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.WORD, 'actor'),
+        new Token(TokenType.PAREN_RIGHT, ')')
+      ])
+      const parsed = parseEntityOptions(tokens)
+      expect(parsed.isActor).to.be.true
+    })
+
+    it('throws for invalid option', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.WORD, 'foo'),
+        new Token(TokenType.PAREN_RIGHT, ')')
+      ])
+      expect(() => parseEntityOptions(tokens)).to.throw()
+    })
+  })
+})

--- a/test/parser/entity/parse-entity.test.ts
+++ b/test/parser/entity/parse-entity.test.ts
@@ -1,0 +1,71 @@
+import { detectEntity, parseEntity } from '../../../src/parser/entity/parse-entity'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+import { EntityType } from '../../../src/sequence/entity'
+
+import { expect } from 'chai'
+
+describe('src/parser/entity/parse-entity.ts', function () {
+  describe('detectEntity()', function () {
+    it('returns true if given keyword "object"', function () {
+      const token = new Token(TokenType.WORD, 'object')
+      expect(detectEntity(token)).to.be.true
+    })
+
+    it('returns false if given a different keyword', function () {
+      const token = new Token(TokenType.WORD, 'foo')
+      expect(detectEntity(token)).to.be.false
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.STRING, '"object"')
+      expect(detectEntity(token)).to.be.false
+    })
+  })
+
+  describe('parseEntity()', function () {
+    it('parses entities without options', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.WORD, 'object'),
+        new Token(TokenType.WORD, 'foo'),
+        new Token(TokenType.EQUALS, '='),
+        new Token(TokenType.STRING, '"Foo"')
+      ])
+      const parsed = parseEntity(tokens)
+      expect(parsed.id).to.equal('foo')
+      expect(parsed.name).to.equal('Foo')
+      expect(parsed.type).to.equal(EntityType.COMPONENT)
+    })
+
+    it('parses entities with empty options', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.WORD, 'object'),
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.PAREN_RIGHT, ')'),
+        new Token(TokenType.WORD, 'foo'),
+        new Token(TokenType.EQUALS, '='),
+        new Token(TokenType.STRING, '"Foo"')
+      ])
+      const parsed = parseEntity(tokens)
+      expect(parsed.id).to.equal('foo')
+      expect(parsed.name).to.equal('Foo')
+      expect(parsed.type).to.equal(EntityType.COMPONENT)
+    })
+
+    it('parses entities with option "actor"', function () {
+      const tokens = new TokenStream([
+        new Token(TokenType.WORD, 'object'),
+        new Token(TokenType.PAREN_LEFT, '('),
+        new Token(TokenType.WORD, 'actor'),
+        new Token(TokenType.PAREN_RIGHT, ')'),
+        new Token(TokenType.WORD, 'foo'),
+        new Token(TokenType.EQUALS, '='),
+        new Token(TokenType.STRING, '"Foo"')
+      ])
+      const parsed = parseEntity(tokens)
+      expect(parsed.id).to.equal('foo')
+      expect(parsed.name).to.equal('Foo')
+      expect(parsed.type).to.equal(EntityType.ACTOR)
+    })
+  })
+})

--- a/test/parser/parser-state.test.ts
+++ b/test/parser/parser-state.test.ts
@@ -1,0 +1,61 @@
+import { ParserState } from '../../src/parser/parser-state'
+import { Entity, EntityType } from '../../src/sequence/entity'
+import { Activation } from '../../src/sequence/activation'
+import { SyncMessage } from '../../src/sequence/message'
+
+import { expect } from 'chai'
+
+describe('src/parser/parser-state.ts', function () {
+  it('has empty entities and activations at first', function () {
+    const obj = new ParserState()
+    expect(obj.getEntities()).to.be.an('array').with.lengthOf(0)
+    expect(obj.getRootActivations()).to.be.an('array').with.lengthOf(0)
+  })
+
+  describe('#insertEntity()', function () {
+    it('add entities to the array', function () {
+      const entity1 = new Entity(EntityType.ACTOR, 'foo', 'Foo')
+      const entity2 = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+      const obj = new ParserState()
+      obj.insertEntity(entity1)
+      expect(obj.getEntities()).to.deep.equal([entity1])
+      obj.insertEntity(entity2)
+      expect(obj.getEntities()).to.deep.equal([entity1, entity2])
+    })
+
+    it('throws for duplicate ids', function () {
+      const entity1 = new Entity(EntityType.ACTOR, 'foo', 'Foo 1')
+      const entity2 = new Entity(EntityType.COMPONENT, 'foo', 'Foo 2')
+      const obj = new ParserState()
+      obj.insertEntity(entity1)
+      expect(() => obj.insertEntity(entity2)).to.throw()
+    })
+  })
+
+  describe('#insertActivation()', function () {
+    it('add activations to the array', function () {
+      const entity1 = new Entity(EntityType.ACTOR, 'foo', 'Foo')
+      const entity2 = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+      const act1 = new Activation(new SyncMessage(entity1, entity2, '1'), undefined, [])
+      const act2 = new Activation(new SyncMessage(entity2, entity1, '2'), undefined, [])
+      const obj = new ParserState()
+      obj.insertActivation(act1)
+      expect(obj.getRootActivations()).to.deep.equal([act1])
+      obj.insertActivation(act2)
+      expect(obj.getRootActivations()).to.deep.equal([act1, act2])
+    })
+  })
+
+  describe('#lookupEntity()', function () {
+    it('returns undefined for unknown ids', function () {
+      const entity1 = new Entity(EntityType.ACTOR, 'foo', 'Foo')
+      const entity2 = new Entity(EntityType.ACTOR, 'bar', 'Bar')
+      const obj = new ParserState()
+      expect(obj.lookupEntity('bar')).to.be.undefined
+      obj.insertEntity(entity1)
+      expect(obj.lookupEntity('bar')).to.be.undefined
+      obj.insertEntity(entity2)
+      expect(obj.lookupEntity('bar')).to.equal(entity2)
+    })
+  })
+})

--- a/test/parser/parser.test.ts
+++ b/test/parser/parser.test.ts
@@ -1,0 +1,38 @@
+import { parse } from '../../src/parser/parser'
+import { TokenStream } from '../../src/tokenizer/token-stream'
+import { Token, TokenType } from '../../src/tokenizer/token'
+
+import { expect } from 'chai'
+
+describe('src/parser/parser.ts', function () {
+  it('parses empty token stream as empty sequence', function () {
+    const tokens = new TokenStream([])
+    const parsed = parse(tokens)
+    expect(parsed.entities).to.have.lengthOf(0)
+    expect(parsed.activations).to.have.lengthOf(0)
+  })
+
+  it('parses objects into entities', function () {
+    const tokens = new TokenStream([
+      new Token(TokenType.WORD, 'object'),
+      new Token(TokenType.WORD, 'foo'),
+      new Token(TokenType.EQUALS, '='),
+      new Token(TokenType.STRING, '"Foo"'),
+      new Token(TokenType.WORD, 'object'),
+      new Token(TokenType.WORD, 'bar'),
+      new Token(TokenType.EQUALS, '='),
+      new Token(TokenType.STRING, '"Bar"')
+    ])
+    const parsed = parse(tokens)
+    expect(parsed.entities).to.have.lengthOf(2)
+    expect(parsed.entities[0].id).to.equal('foo')
+    expect(parsed.entities[1].id).to.equal('bar')
+  })
+
+  it('throws for unexpected token (global level)', function () {
+    const tokens = new TokenStream([
+      new Token(TokenType.WORD, '"hello world"')
+    ])
+    expect(() => parse(tokens)).to.throw()
+  })
+})

--- a/test/parser/unquote.test.ts
+++ b/test/parser/unquote.test.ts
@@ -1,0 +1,18 @@
+import { unquote } from '../../src/parser/unquote'
+import { Token, TokenType } from '../../src/tokenizer/token'
+
+import { expect } from 'chai'
+
+describe('src/parser/unquote.ts', function () {
+  it('throws for tokens that are not strings', function () {
+    expect(() => unquote(new Token(TokenType.WORD, '"foo"'))).to.throw()
+  })
+
+  it('returns the token value without beginning and end quote', function () {
+    expect(unquote(new Token(TokenType.STRING, '"foo"'))).to.equal('foo')
+  })
+
+  it('ignores all other quotes', function () {
+    expect(unquote(new Token(TokenType.STRING, '"foo " \\" "" "'))).to.equal('foo " \\" "" ')
+  })
+})


### PR DESCRIPTION
This PR adds the parser interface and implements the first syntactic feature: object definitions.
Objects can be defined intuitively, just like assigning a string variable in other languages:

```
object myComponent = "comp: Component"
```

The above would create a _Component Object_ with entity id `myComponent` and diagram label "comp: Component".
Changing the entity type from component to Actor works by providing an option to the assignment:

```
object(actor) myActor = "User"
```

There can be as many objects as one wants, and they will be parsed in order and added to the sequence.

```
object myComponent = "comp: Component"
object(actor) myActor = "User"
object foo = "foo: Foo"
object bar = ":Bar"
```

This syntax was chosen to be extensible to many different object types, vs. using separate keywords for each one.