### PR TITLE
Implement comment tokens, skipped when parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 Every Lifeline script consists of an Object Definition Section followed by a
 Message Section.
 There can be many object definitions and many messages.
+The language includes support for comments (pieces of text not to be included
+in the diagram).
 
 ### Object Definitions
 
@@ -24,3 +26,17 @@ object(actor) bar = "Bar"
 
 This will create one _component object_ with id `foo` and label `Foo`,
 as well as one _actor object_ with id `bar` and label `Bar`.
+
+### Comments
+
+Comments can be used to include notes in the Lifeline script that should not
+appear in the diagram.
+They can be positioned anywhere (except inside of strings) and begin with the
+hash symbol `#`.
+They extend to the end of the line.
+For example:
+
+```
+# this is a comment
+object foo = "Foo"  # this is another comment
+```

--- a/src/parser/entity/parse-entity.ts
+++ b/src/parser/entity/parse-entity.ts
@@ -1,10 +1,10 @@
-import { TokenStream } from '../../tokenizer/token-stream'
 import { Entity, EntityType } from '../../sequence/entity'
 import { Token, TokenType } from '../../tokenizer/token'
 import { unquote } from '../unquote'
 import { detectEntityOptions, parseEntityOptions } from './parse-entity-options'
 import { keywords } from '../strings'
 import { defaultEntityOptions } from './entity-options'
+import { TokenAccessor } from '../token-accessor'
 
 /**
  * Determine whether the given token marks the beginning of an entity definition.
@@ -20,10 +20,10 @@ export function detectEntity (token: Token): boolean {
 /**
  * Force-parse an entity definition from the given stream.
  *
- * @param {TokenStream} tokens The input stream.
+ * @param {TokenAccessor} tokens The input stream.
  * @returns {Entity} The parsed entity.
  */
-export function parseEntity (tokens: TokenStream): Entity {
+export function parseEntity (tokens: TokenAccessor): Entity {
   tokens.pop(TokenType.WORD, keywords.object)
 
   const options = detectEntityOptions(tokens.peek())

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,19 +1,56 @@
-import { Token } from '../tokenizer/token'
+import { Token, TokenType } from '../tokenizer/token'
 
-export class UnexpectedTokenError extends Error {
-  constructor (token: Token) {
-    super(`unexpected token <${token.type}> '${token.value}'`)
+/**
+ * A generic error type for everything related to parsing.
+ * This contains a token attribute that stores the token causing the error (or a token roughly in the vicinity).
+ */
+export class ParserError extends Error {
+  readonly token: Token
+
+  constructor (token: Token, message: string) {
+    super(message)
+    this.token = token
   }
 }
 
-export class UnsupportedOptionError extends Error {
-  constructor (option: string, supported: string[]) {
-    super(`unsupported option ${option}, valid options are: ${supported.join(', ')}`)
+/**
+ * Thrown when a token of a different type, or with a different value, was requested
+ * than the token currently present in the stream.
+ */
+export class UnexpectedTokenError extends ParserError {
+  readonly expectedType: TokenType | undefined
+
+  constructor (actual: Token, expectedType?: TokenType, expectedValue?: string) {
+    super(actual, UnexpectedTokenError.formatMessage(actual, expectedType, expectedValue))
+    this.expectedType = expectedType
+  }
+
+  private static formatMessage (actual: Token, expectedType?: TokenType, expectedValue?: string): string {
+    if (expectedValue == null) {
+      if (expectedType == null) {
+        return `unexpected token <${actual.type}>`
+      }
+      return `unexpected token <${actual.type}>, expected <${expectedType}>`
+    }
+    const expType = expectedType == null ? actual.type : expectedType
+    return `unexpected token <${actual.type}> '${actual.value}', expected <${expType}> '${expectedValue}'`
   }
 }
 
-export class DuplicateOptionError extends Error {
-  constructor (option: string) {
-    super(`duplicate option ${option}`)
+/**
+ * Thrown when an invalid option is encountered.
+ */
+export class UnsupportedOptionError extends ParserError {
+  constructor (token: Token, option: string, supported: string[]) {
+    super(token, `unsupported option ${option}, valid options are: ${supported.join(', ')}`)
+  }
+}
+
+/**
+ * Thrown when an option is named twice.
+ */
+export class DuplicateOptionError extends ParserError {
+  constructor (token: Token, option: string) {
+    super(token, `duplicate option ${option}`)
   }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,8 +1,10 @@
 import { TokenStream } from '../tokenizer/token-stream'
 import { Sequence } from '../sequence/sequence'
 import { ParserState } from './parser-state'
-import { UnexpectedTokenError } from './errors'
 import { detectEntity, parseEntity } from './entity/parse-entity'
+import { UnexpectedTokenError } from './errors'
+import { TokenAccessor } from './token-accessor'
+import { TokenType } from '../tokenizer/token'
 
 /**
  * Parse the given stream of tokens into a sequence.
@@ -11,14 +13,17 @@ import { detectEntity, parseEntity } from './entity/parse-entity'
  *
  * @param {TokenStream} tokens The input token stream as produced by the tokenizer.
  * @returns {Sequence} The parsed sequence.
+ * @throws {ParserError} If an error occurs during parsing.
  */
 export function parse (tokens: TokenStream): Sequence {
   const state = new ParserState()
 
-  while (tokens.hasNext()) {
+  const accessor = new TokenAccessor(tokens, [TokenType.COMMENT])
+
+  while (accessor.hasNext()) {
     const token = tokens.peek()
     if (detectEntity(token)) {
-      state.insertEntity(parseEntity(tokens))
+      state.insertEntity(parseEntity(accessor))
       continue
     }
     throw new UnexpectedTokenError(token)

--- a/src/parser/token-accessor.ts
+++ b/src/parser/token-accessor.ts
@@ -1,0 +1,87 @@
+import { Token, TokenType } from '../tokenizer/token'
+import { TokenStream } from '../tokenizer/token-stream'
+import { UnexpectedTokenError } from './errors'
+
+/**
+ * This class operates on a TokenStream.
+ *
+ * It extends the basic functionality of such a stream by enabling typesafe removal of tokens,
+ * i.e. a token type can be asserted when obtaining it.
+ *
+ * Moreover, a set of skipped token types can be configured.
+ * These tokens will be ignored completely (it will be as if they did not occur at all in the input stream).
+ * This is useful for stripping out comments.
+ */
+export class TokenAccessor {
+  private readonly stream: TokenStream
+  private readonly skip: ReadonlySet<TokenType>
+
+  constructor (stream: TokenStream, skip?: TokenType[]) {
+    this.stream = stream
+    this.skip = new Set(skip)
+  }
+
+  private advanceSkippedTokens (): void {
+    while (this.stream.hasNext() && this.skip.has(this.stream.peek().type)) {
+      this.stream.next()
+    }
+  }
+
+  /**
+   * Check stream state.
+   *
+   * @returns {boolean} Whether there are any more tokens left.
+   */
+  hasNext (): boolean {
+    this.advanceSkippedTokens()
+    return this.stream.hasNext()
+  }
+
+  /**
+   * Retrieve the next token without advancing the stream.
+   *
+   * @returns {Token} The next token in the stream.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   */
+  peek (): Token {
+    this.advanceSkippedTokens()
+    return this.stream.peek()
+  }
+
+  /**
+   * Obtain the next token and advance the stream, but only if the token matches the given type.
+   * If the type does not match, this returns undefined and the stream does not change state.
+   *
+   * @param {TokenType} type The type of token to pop off.
+   * @returns {Token | undefined} The next token in the stream, or undefined.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   */
+  popOptional (type: TokenType): Token | undefined {
+    const token = this.peek()
+    if (token.type !== type) {
+      return undefined
+    }
+    return this.stream.next()
+  }
+
+  /**
+   * Obtain the next token and advance the stream. The token must be of the given type,
+   * otherwise an error will be thrown. Optionally, the token value can be asserted in the same manner.
+   *
+   * @param {TokenType} type The type of token to pop off.
+   * @param {?string} value The value the token is expected to have.
+   * @returns {Token} The next token.
+   * @throws {EndOfStreamError} If there is no remaining token.
+   * @throws {UnexpectedTokenError} If the token type mismatches, or a value was specified and it mismatches.
+   */
+  pop (type: TokenType, value?: string): Token {
+    const optToken = this.popOptional(type)
+    if (optToken == null) {
+      throw new UnexpectedTokenError(this.peek(), type)
+    }
+    if (value != null && optToken.value !== value) {
+      throw new UnexpectedTokenError(optToken, type, value)
+    }
+    return optToken
+  }
+}

--- a/src/tokenizer/errors.ts
+++ b/src/tokenizer/errors.ts
@@ -1,56 +1,35 @@
-import { Token, TokenType } from './token'
+export class TokenizerError extends Error {
+  readonly position: number
+
+  constructor (position: number, message: string) {
+    super(message)
+    this.position = position
+  }
+}
 
 /**
  * Thrown when an input is given for which a token type cannot be determined.
  */
-export class UnknownTokenTypeError extends Error {
-  constructor () {
-    super('unable to determine token type')
+export class UnknownTokenTypeError extends TokenizerError {
+  constructor (position: number) {
+    super(position, 'unable to determine token type')
   }
 }
 
 /**
  * Thrown when a string token is detected, but there is no closing quote.
  */
-export class UnterminatedStringError extends Error {
-  constructor () {
-    super('unterminated string')
+export class UnterminatedStringError extends TokenizerError {
+  constructor (position: number) {
+    super(position, 'unterminated string')
   }
 }
 
 /**
  * Thrown when another token is requested from the stream, but no more tokens exist.
  */
-export class EndOfStreamError extends Error {
-  constructor () {
-    super('end of stream reached')
-  }
-}
-
-/**
- * Thrown when a token of a different type was requested than is currently present in the stream.
- */
-export class UnexpectedTokenTypeError extends Error {
-  readonly actual: Token
-  readonly expectedType: TokenType
-
-  constructor (actual: Token, expectedType: TokenType) {
-    super(`unexpected token <${actual.type}>, expected <${expectedType}>`)
-    this.actual = actual
-    this.expectedType = expectedType
-  }
-}
-
-/**
- * Thrown when a token with a different value was requested than is currently present in the stream.
- */
-export class UnexpectedTokenValueError extends Error {
-  readonly actual: Token
-  readonly expectedValue: string
-
-  constructor (actual: Token, expectedValue: string) {
-    super(`unexpected token value '${actual.value}', expected '${expectedValue}'`)
-    this.actual = actual
-    this.expectedValue = expectedValue
+export class EndOfStreamError extends TokenizerError {
+  constructor (position: number) {
+    super(position, 'end of stream reached')
   }
 }

--- a/src/tokenizer/token-stream.ts
+++ b/src/tokenizer/token-stream.ts
@@ -1,5 +1,5 @@
-import { Token, TokenType } from './token'
-import { EndOfStreamError, UnexpectedTokenTypeError, UnexpectedTokenValueError } from './errors'
+import { Token } from './token'
+import { EndOfStreamError } from './errors'
 
 /**
  * A stream of tokens that allows for sequential processing.
@@ -24,54 +24,27 @@ export class TokenStream {
   }
 
   /**
-   * Obtain the next token without advancing the stream.
+   * Retrieve the next token without advancing the stream.
    *
    * @returns {Token} The next token in the stream.
    * @throws {EndOfStreamError} If there is no remaining token.
    */
   peek (): Token {
     if (!this.hasNext()) {
-      throw new EndOfStreamError()
+      throw new EndOfStreamError(0)
     }
     return this.tokens[this.nextPointer]
   }
 
   /**
-   * Obtain the next token and advance the stream, but only if the token matches the given type.
-   * If the type does not match, this returns undefined and the stream does not change state.
+   * Obtain the next token in the stream, consuming it.
    *
-   * @param {TokenType} type The type of token to pop off.
-   * @returns {Token | undefined} The next token in the stream, or undefined.
-   * @throws {EndOfStreamError} If there is no remaining token.
-   */
-  popOptional (type: TokenType): Token | undefined {
-    const token = this.peek()
-    if (token.type !== type) {
-      return undefined
-    }
-    ++this.nextPointer
-    return token
-  }
-
-  /**
-   * Obtain the next token and advance the stream. The token must be of the given type,
-   * otherwise an error will be thrown. Optionally, the token value can be asserted in the same manner.
-   *
-   * @param {TokenType} type The type of token to pop off.
-   * @param {?string} value The value the token is expected to have.
    * @returns {Token} The next token in the stream.
    * @throws {EndOfStreamError} If there is no remaining token.
-   * @throws {UnexpectedTokenTypeError} If the token type mismatches.
-   * @throws {UnexpectedTokenValueError} If a token value was specified, and it mismatches.
    */
-  pop (type: TokenType, value?: string): Token {
-    const optToken = this.popOptional(type)
-    if (optToken == null) {
-      throw new UnexpectedTokenTypeError(this.peek(), type)
-    }
-    if (value != null && optToken.value !== value) {
-      throw new UnexpectedTokenValueError(optToken, value)
-    }
-    return optToken
+  next (): Token {
+    const token = this.peek()
+    ++this.nextPointer
+    return token
   }
 }

--- a/src/tokenizer/token.ts
+++ b/src/tokenizer/token.ts
@@ -1,4 +1,5 @@
 export enum TokenType {
+  COMMENT = 'comment',
   WORD = 'word',
   EQUALS = 'equals',
   COLON = 'colon',
@@ -15,10 +16,12 @@ export enum TokenType {
  */
 export class Token {
   readonly type: TokenType
+  readonly position: number
   readonly value: string
 
-  constructor (type: TokenType, value: string) {
+  constructor (type: TokenType, position: number, value: string) {
     this.type = type
+    this.position = position
     this.value = value
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,9 +13,9 @@ describe('index.ts', function () {
     it('performs tokenization', function () {
       const result = index.tokenize('foo : "bar"')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.WORD).value).to.equal('foo')
-      expect(result.pop(TokenType.COLON).value).to.equal(':')
-      expect(result.pop(TokenType.STRING).value).to.equal('"bar"')
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo' })
+      expect(result.next()).to.include({ type: TokenType.COLON, value: ':' })
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"bar"' })
     })
   })
 
@@ -26,10 +26,10 @@ describe('index.ts', function () {
 
     it('performs parsing', function () {
       const tokens = new TokenStream([
-        new Token(TokenType.WORD, 'object'),
-        new Token(TokenType.WORD, 'foo'),
-        new Token(TokenType.EQUALS, '='),
-        new Token(TokenType.STRING, '"bar"')
+        new Token(TokenType.WORD, 0, 'object'),
+        new Token(TokenType.WORD, 7, 'foo'),
+        new Token(TokenType.EQUALS, 10, '='),
+        new Token(TokenType.STRING, 11, '"bar"')
       ])
 
       const result = index.parse(tokens)

--- a/test/parser/entity/parse-entity-options.test.ts
+++ b/test/parser/entity/parse-entity-options.test.ts
@@ -3,46 +3,47 @@ import { Token, TokenType } from '../../../src/tokenizer/token'
 import { TokenStream } from '../../../src/tokenizer/token-stream'
 
 import { expect } from 'chai'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
 
 describe('src/parser/entity/parse-entity-options.ts', function () {
   describe('detectEntityOptions()', function () {
     it('returns true if given left paren', function () {
-      const token = new Token(TokenType.PAREN_LEFT, '(')
+      const token = new Token(TokenType.PAREN_LEFT, 0, '(')
       expect(detectEntityOptions(token)).to.be.true
     })
 
     it('returns false if given a different token type', function () {
-      const token = new Token(TokenType.WORD, 'foo')
+      const token = new Token(TokenType.WORD, 0, 'foo')
       expect(detectEntityOptions(token)).to.be.false
     })
   })
 
   describe('parseEntityOptions()', function () {
     it('returns defaults for empty options', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.PAREN_RIGHT, ')')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.PAREN_LEFT, 0, '('),
+        new Token(TokenType.PAREN_RIGHT, 1, ')')
+      ]))
       const parsed = parseEntityOptions(tokens)
       expect(parsed.isActor).to.be.false
     })
 
     it('parses actor option', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.WORD, 'actor'),
-        new Token(TokenType.PAREN_RIGHT, ')')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.PAREN_LEFT, 0, '('),
+        new Token(TokenType.WORD, 1, 'actor'),
+        new Token(TokenType.PAREN_RIGHT, 6, ')')
+      ]))
       const parsed = parseEntityOptions(tokens)
       expect(parsed.isActor).to.be.true
     })
 
     it('throws for invalid option', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.WORD, 'foo'),
-        new Token(TokenType.PAREN_RIGHT, ')')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.PAREN_LEFT, 0, '('),
+        new Token(TokenType.WORD, 1, 'foo'),
+        new Token(TokenType.PAREN_RIGHT, 4, ')')
+      ]))
       expect(() => parseEntityOptions(tokens)).to.throw()
     })
   })

--- a/test/parser/entity/parse-entity.test.ts
+++ b/test/parser/entity/parse-entity.test.ts
@@ -4,33 +4,34 @@ import { TokenStream } from '../../../src/tokenizer/token-stream'
 import { EntityType } from '../../../src/sequence/entity'
 
 import { expect } from 'chai'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
 
 describe('src/parser/entity/parse-entity.ts', function () {
   describe('detectEntity()', function () {
     it('returns true if given keyword "object"', function () {
-      const token = new Token(TokenType.WORD, 'object')
+      const token = new Token(TokenType.WORD, 0, 'object')
       expect(detectEntity(token)).to.be.true
     })
 
     it('returns false if given a different keyword', function () {
-      const token = new Token(TokenType.WORD, 'foo')
+      const token = new Token(TokenType.WORD, 0, 'foo')
       expect(detectEntity(token)).to.be.false
     })
 
     it('returns false if given a different token type', function () {
-      const token = new Token(TokenType.STRING, '"object"')
+      const token = new Token(TokenType.STRING, 0, '"object"')
       expect(detectEntity(token)).to.be.false
     })
   })
 
   describe('parseEntity()', function () {
     it('parses entities without options', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.WORD, 'object'),
-        new Token(TokenType.WORD, 'foo'),
-        new Token(TokenType.EQUALS, '='),
-        new Token(TokenType.STRING, '"Foo"')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.WORD, 0, 'object'),
+        new Token(TokenType.WORD, 7, 'foo'),
+        new Token(TokenType.EQUALS, 10, '='),
+        new Token(TokenType.STRING, 11, '"Foo"')
+      ]))
       const parsed = parseEntity(tokens)
       expect(parsed.id).to.equal('foo')
       expect(parsed.name).to.equal('Foo')
@@ -38,14 +39,14 @@ describe('src/parser/entity/parse-entity.ts', function () {
     })
 
     it('parses entities with empty options', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.WORD, 'object'),
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.PAREN_RIGHT, ')'),
-        new Token(TokenType.WORD, 'foo'),
-        new Token(TokenType.EQUALS, '='),
-        new Token(TokenType.STRING, '"Foo"')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.WORD, 0, 'object'),
+        new Token(TokenType.PAREN_LEFT, 7, '('),
+        new Token(TokenType.PAREN_RIGHT, 8, ')'),
+        new Token(TokenType.WORD, 9, 'foo'),
+        new Token(TokenType.EQUALS, 12, '='),
+        new Token(TokenType.STRING, 13, '"Foo"')
+      ]))
       const parsed = parseEntity(tokens)
       expect(parsed.id).to.equal('foo')
       expect(parsed.name).to.equal('Foo')
@@ -53,15 +54,15 @@ describe('src/parser/entity/parse-entity.ts', function () {
     })
 
     it('parses entities with option "actor"', function () {
-      const tokens = new TokenStream([
-        new Token(TokenType.WORD, 'object'),
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.WORD, 'actor'),
-        new Token(TokenType.PAREN_RIGHT, ')'),
-        new Token(TokenType.WORD, 'foo'),
-        new Token(TokenType.EQUALS, '='),
-        new Token(TokenType.STRING, '"Foo"')
-      ])
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.WORD, 0, 'object'),
+        new Token(TokenType.PAREN_LEFT, 7, '('),
+        new Token(TokenType.WORD, 8, 'actor'),
+        new Token(TokenType.PAREN_RIGHT, 13, ')'),
+        new Token(TokenType.WORD, 14, 'foo'),
+        new Token(TokenType.EQUALS, 17, '='),
+        new Token(TokenType.STRING, 18, '"Foo"')
+      ]))
       const parsed = parseEntity(tokens)
       expect(parsed.id).to.equal('foo')
       expect(parsed.name).to.equal('Foo')

--- a/test/parser/parser.test.ts
+++ b/test/parser/parser.test.ts
@@ -14,14 +14,14 @@ describe('src/parser/parser.ts', function () {
 
   it('parses objects into entities', function () {
     const tokens = new TokenStream([
-      new Token(TokenType.WORD, 'object'),
-      new Token(TokenType.WORD, 'foo'),
-      new Token(TokenType.EQUALS, '='),
-      new Token(TokenType.STRING, '"Foo"'),
-      new Token(TokenType.WORD, 'object'),
-      new Token(TokenType.WORD, 'bar'),
-      new Token(TokenType.EQUALS, '='),
-      new Token(TokenType.STRING, '"Bar"')
+      new Token(TokenType.WORD, 0, 'object'),
+      new Token(TokenType.WORD, 7, 'foo'),
+      new Token(TokenType.EQUALS, 10, '='),
+      new Token(TokenType.STRING, 11, '"Foo"'),
+      new Token(TokenType.WORD, 16, 'object'),
+      new Token(TokenType.WORD, 24, 'bar'),
+      new Token(TokenType.EQUALS, 27, '='),
+      new Token(TokenType.STRING, 28, '"Bar"')
     ])
     const parsed = parse(tokens)
     expect(parsed.entities).to.have.lengthOf(2)
@@ -31,8 +31,23 @@ describe('src/parser/parser.ts', function () {
 
   it('throws for unexpected token (global level)', function () {
     const tokens = new TokenStream([
-      new Token(TokenType.WORD, '"hello world"')
+      new Token(TokenType.WORD, 0, '"hello world"')
     ])
     expect(() => parse(tokens)).to.throw()
+  })
+
+  it('ignores comments', function () {
+    const tokens = new TokenStream([
+      new Token(TokenType.COMMENT, 0, '# comment'),
+      new Token(TokenType.WORD, 12, 'object'),
+      new Token(TokenType.WORD, 19, 'foo'),
+      new Token(TokenType.COMMENT, 22, '# comment'),
+      new Token(TokenType.EQUALS, 30, '='),
+      new Token(TokenType.STRING, 31, '"Foo"')
+    ])
+    const parsed = parse(tokens)
+    expect(parsed.entities).to.have.lengthOf(1)
+    expect(parsed.entities[0].id).to.equal('foo')
+    expect(parsed.activations).to.have.lengthOf(0)
   })
 })

--- a/test/parser/token-accessor.test.ts
+++ b/test/parser/token-accessor.test.ts
@@ -1,0 +1,208 @@
+import { TokenAccessor } from '../../src/parser/token-accessor'
+import { Token, TokenType } from '../../src/tokenizer/token'
+import { UnexpectedTokenError } from '../../src/parser/errors'
+import { TokenStream } from '../../src/tokenizer/token-stream'
+
+import { expect } from 'chai'
+
+describe('src/parser/token-accessor.ts', function () {
+  describe('#hasNext()', function () {
+    it('returns false for empty stream', function () {
+      const stream = new TokenStream([])
+      expect(new TokenAccessor(stream).hasNext()).to.be.false
+    })
+
+    it('returns true for non-empty stream', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.WORD, 0, 'test')
+      ])
+      expect(new TokenAccessor(stream).hasNext()).to.be.true
+    })
+
+    it('returns false for streams containing only skipped tokens', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test')
+      ])
+      expect(new TokenAccessor(stream, [TokenType.COMMENT]).hasNext()).to.be.false
+    })
+
+    it('returns true for streams containing non-skipped tokens after skipped tokens', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test'),
+        new Token(TokenType.WORD, 14, 'foo')
+      ])
+      expect(new TokenAccessor(stream, [TokenType.COMMENT]).hasNext()).to.be.true
+    })
+  })
+
+  describe('#peek()', function () {
+    it('throws an error if called on empty stream', function () {
+      const stream = new TokenStream([])
+      expect(() => new TokenAccessor(stream).peek()).to.throw()
+    })
+
+    it('throws an error if called on streams containing only skipped tokens', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test')
+      ])
+      expect(() => new TokenAccessor(stream, [TokenType.COMMENT]).peek()).to.throw()
+    })
+
+    it('returns first token', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).peek()).to.equal(tokens[0])
+    })
+
+    it('returns first token after skipping', function () {
+      const tokens = [
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test'),
+        new Token(TokenType.WORD, 14, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream, [TokenType.COMMENT]).peek()).to.equal(tokens[2])
+    })
+
+    it('does not advance the stream (when not skipping)', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      const obj = new TokenAccessor(stream)
+      expect(obj.peek()).to.equal(obj.peek())
+      expect(obj.hasNext()).to.be.true
+    })
+  })
+
+  describe('#popOptional()', function () {
+    it('throws an error if called on empty stream', function () {
+      const stream = new TokenStream([])
+      expect(() => new TokenAccessor(stream).popOptional(TokenType.WORD)).to.throw()
+    })
+
+    it('throws an error if called on streams containing only skipped tokens', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test')
+      ])
+      expect(() => new TokenAccessor(stream, [TokenType.COMMENT]).popOptional(TokenType.COMMENT)).to.throw()
+    })
+
+    it('returns undefined when requesting a skipped token', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test'),
+        new Token(TokenType.WORD, 14, 'foo')
+      ])
+      expect(new TokenAccessor(stream, [TokenType.COMMENT]).popOptional(TokenType.COMMENT)).to.be.undefined
+    })
+
+    it('returns token if type matches', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).popOptional(TokenType.WORD)).to.equal(tokens[0])
+    })
+
+    it('returns undefined if type does not match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).popOptional(TokenType.PAREN_LEFT)).to.be.undefined
+    })
+
+    it('advances the stream, but only on a match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      const obj = new TokenAccessor(stream)
+      obj.popOptional(TokenType.PAREN_LEFT)
+      expect(obj.hasNext()).to.be.true
+      obj.popOptional(TokenType.WORD)
+      expect(obj.hasNext()).to.be.false
+    })
+
+    it('works multiple times in a row', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test'),
+        new Token(TokenType.PAREN_LEFT, 5, '('),
+        new Token(TokenType.PAREN_RIGHT, 6, '(')
+      ]
+      const stream = new TokenStream(tokens)
+      const obj = new TokenAccessor(stream)
+      expect(obj.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(obj.popOptional(TokenType.WORD)).to.equal(tokens[0])
+      expect(obj.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(obj.popOptional(TokenType.PAREN_LEFT)).to.equal(tokens[1])
+      expect(obj.popOptional(TokenType.EQUALS)).to.be.undefined
+      expect(obj.popOptional(TokenType.PAREN_RIGHT)).to.equal(tokens[2])
+      expect(obj.hasNext()).to.be.false
+    })
+  })
+
+  describe('#pop()', function () {
+    it('throws an error if called on empty stream', function () {
+      const stream = new TokenStream([])
+      expect(() => new TokenAccessor(stream).pop(TokenType.WORD)).to.throw()
+    })
+
+    it('throws an error if called on streams containing only skipped tokens', function () {
+      const stream = new TokenStream([
+        new Token(TokenType.COMMENT, 0, '#test'),
+        new Token(TokenType.COMMENT, 7, '#test')
+      ])
+      expect(() => new TokenAccessor(stream, [TokenType.COMMENT]).pop(TokenType.COMMENT)).to.throw()
+    })
+
+    it('returns token if type matches', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).pop(TokenType.WORD)).to.equal(tokens[0])
+    })
+
+    it('returns token if type and value match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).pop(TokenType.WORD, 'test')).to.equal(tokens[0])
+    })
+
+    it('throws if type does not match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(() => new TokenAccessor(stream).pop(TokenType.PAREN_LEFT)).to.throw(UnexpectedTokenError)
+    })
+
+    it('throws if type matches, but value does not', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(() => new TokenAccessor(stream).pop(TokenType.WORD, 'foo')).to.throw(UnexpectedTokenError)
+    })
+
+    it('advances the stream on a match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      const obj = new TokenAccessor(stream)
+      obj.pop(TokenType.WORD)
+      expect(obj.hasNext()).to.be.false
+    })
+  })
+})

--- a/test/parser/unquote.test.ts
+++ b/test/parser/unquote.test.ts
@@ -5,14 +5,14 @@ import { expect } from 'chai'
 
 describe('src/parser/unquote.ts', function () {
   it('throws for tokens that are not strings', function () {
-    expect(() => unquote(new Token(TokenType.WORD, '"foo"'))).to.throw()
+    expect(() => unquote(new Token(TokenType.WORD, 0, '"foo"'))).to.throw()
   })
 
   it('returns the token value without beginning and end quote', function () {
-    expect(unquote(new Token(TokenType.STRING, '"foo"'))).to.equal('foo')
+    expect(unquote(new Token(TokenType.STRING, 0, '"foo"'))).to.equal('foo')
   })
 
   it('ignores all other quotes', function () {
-    expect(unquote(new Token(TokenType.STRING, '"foo " \\" "" "'))).to.equal('foo " \\" "" ')
+    expect(unquote(new Token(TokenType.STRING, 0, '"foo " \\" "" "'))).to.equal('foo " \\" "" ')
   })
 })

--- a/test/tokenizer/token-stream.test.ts
+++ b/test/tokenizer/token-stream.test.ts
@@ -1,8 +1,8 @@
 import { TokenStream } from '../../src/tokenizer/token-stream'
 import { Token, TokenType } from '../../src/tokenizer/token'
-import { UnexpectedTokenTypeError, UnexpectedTokenValueError } from '../../src/tokenizer/errors'
 
 import { expect } from 'chai'
+import { EndOfStreamError } from '../../src/tokenizer/errors'
 
 describe('src/tokenizer/token-stream.ts', function () {
   describe('#hasNext()', function () {
@@ -12,7 +12,7 @@ describe('src/tokenizer/token-stream.ts', function () {
 
     it('returns true for non-empty stream', function () {
       const tokens = [
-        new Token(TokenType.WORD, 'test')
+        new Token(TokenType.WORD, 0, 'test')
       ]
       expect(new TokenStream(tokens).hasNext()).to.be.true
     })
@@ -25,14 +25,14 @@ describe('src/tokenizer/token-stream.ts', function () {
 
     it('returns first token', function () {
       const tokens = [
-        new Token(TokenType.WORD, 'test')
+        new Token(TokenType.WORD, 0, 'test')
       ]
       expect(new TokenStream(tokens).peek()).to.equal(tokens[0])
     })
 
     it('does not advance the stream', function () {
       const tokens = [
-        new Token(TokenType.WORD, 'test')
+        new Token(TokenType.WORD, 0, 'test')
       ]
       const obj = new TokenStream(tokens)
       expect(obj.peek()).to.equal(obj.peek())
@@ -40,93 +40,28 @@ describe('src/tokenizer/token-stream.ts', function () {
     })
   })
 
-  describe('#popOptional()', function () {
+  describe('#next()', function () {
     it('throws an error if called on empty stream', function () {
-      expect(() => new TokenStream([]).popOptional(TokenType.WORD)).to.throw()
+      expect(() => new TokenStream([]).next()).to.throw()
     })
 
-    it('returns token if type matches', function () {
+    it('returns token', function () {
       const tokens = [
-        new Token(TokenType.WORD, 'test')
+        new Token(TokenType.WORD, 0, 'test')
       ]
-      expect(new TokenStream(tokens).popOptional(TokenType.WORD)).to.equal(tokens[0])
-    })
-
-    it('returns undefined if type does not match', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      expect(new TokenStream(tokens).popOptional(TokenType.PAREN_LEFT)).to.be.undefined
-    })
-
-    it('advances the stream, but only on a match', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      const stream = new TokenStream(tokens)
-      stream.popOptional(TokenType.PAREN_LEFT)
-      expect(stream.hasNext()).to.be.true
-      stream.popOptional(TokenType.WORD)
-      expect(stream.hasNext()).to.be.false
-    })
-
-    it('works multiple times in a row', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test'),
-        new Token(TokenType.PAREN_LEFT, '('),
-        new Token(TokenType.PAREN_RIGHT, '(')
-      ]
-      const stream = new TokenStream(tokens)
-      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
-      expect(stream.popOptional(TokenType.WORD)).to.equal(tokens[0])
-      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
-      expect(stream.popOptional(TokenType.PAREN_LEFT)).to.equal(tokens[1])
-      expect(stream.popOptional(TokenType.EQUALS)).to.be.undefined
-      expect(stream.popOptional(TokenType.PAREN_RIGHT)).to.equal(tokens[2])
-      expect(stream.hasNext()).to.be.false
-    })
-  })
-
-  describe('#pop()', function () {
-    it('throws an error if called on empty stream', function () {
-      expect(() => new TokenStream([]).pop(TokenType.WORD)).to.throw()
-    })
-
-    it('returns token if type matches', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      expect(new TokenStream(tokens).pop(TokenType.WORD)).to.equal(tokens[0])
-    })
-
-    it('returns token if type and value match', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      expect(new TokenStream(tokens).pop(TokenType.WORD, 'test')).to.equal(tokens[0])
-    })
-
-    it('throws if type does not match', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      expect(() => new TokenStream(tokens).pop(TokenType.PAREN_LEFT)).to.throw(UnexpectedTokenTypeError)
-    })
-
-    it('throws if type matches, but value does not', function () {
-      const tokens = [
-        new Token(TokenType.WORD, 'test')
-      ]
-      expect(() => new TokenStream(tokens).pop(TokenType.WORD, 'foo')).to.throw(UnexpectedTokenValueError)
+      expect(new TokenStream(tokens).next()).to.equal(tokens[0])
     })
 
     it('advances the stream on a match', function () {
       const tokens = [
-        new Token(TokenType.WORD, 'test')
+        new Token(TokenType.WORD, 0, 'test'),
+        new Token(TokenType.STRING, 4, '"foo"')
       ]
       const stream = new TokenStream(tokens)
-      stream.pop(TokenType.WORD)
+      expect(stream.next()).to.equal(tokens[0])
+      expect(stream.next()).to.equal(tokens[1])
       expect(stream.hasNext()).to.be.false
+      expect(() => stream.next()).to.throw(EndOfStreamError)
     })
   })
 })

--- a/test/tokenizer/tokenizer.test.ts
+++ b/test/tokenizer/tokenizer.test.ts
@@ -22,43 +22,43 @@ describe('src/tokenizer/tokenizer.ts', function () {
     it('detects all token types correctly if placed in sequence', function () {
       const result = tokenize('= ( ) { } : foo "bar baz" word$with.special*chars')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.EQUALS).value).to.equal('=')
-      expect(result.pop(TokenType.PAREN_LEFT).value).to.equal('(')
-      expect(result.pop(TokenType.PAREN_RIGHT).value).to.equal(')')
-      expect(result.pop(TokenType.BLOCK_LEFT).value).to.equal('{')
-      expect(result.pop(TokenType.BLOCK_RIGHT).value).to.equal('}')
-      expect(result.pop(TokenType.COLON).value).to.equal(':')
-      expect(result.pop(TokenType.WORD).value).to.equal('foo')
-      expect(result.pop(TokenType.STRING).value).to.equal('"bar baz"')
-      expect(result.pop(TokenType.WORD).value).to.equal('word$with.special*chars')
+      expect(result.next()).to.include({ type: TokenType.EQUALS, value: '=' })
+      expect(result.next()).to.include({ type: TokenType.PAREN_LEFT, value: '(' })
+      expect(result.next()).to.include({ type: TokenType.PAREN_RIGHT, value: ')' })
+      expect(result.next()).to.include({ type: TokenType.BLOCK_LEFT, value: '{' })
+      expect(result.next()).to.include({ type: TokenType.BLOCK_RIGHT, value: '}' })
+      expect(result.next()).to.include({ type: TokenType.COLON, value: ':' })
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo' })
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"bar baz"' })
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'word$with.special*chars' })
     })
 
     it('detects strings', function () {
       const result = tokenize('"foo bar" "baz" "key:value" "call()"')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.STRING).value).to.equal('"foo bar"')
-      expect(result.pop(TokenType.STRING).value).to.equal('"baz"')
-      expect(result.pop(TokenType.STRING).value).to.equal('"key:value"')
-      expect(result.pop(TokenType.STRING).value).to.equal('"call()"')
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"foo bar"' })
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"baz"' })
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"key:value"' })
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"call()"' })
     })
 
     it('detects words', function () {
       const result = tokenize('foo foo_bar b*z')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.WORD).value).to.equal('foo')
-      expect(result.pop(TokenType.WORD).value).to.equal('foo_bar')
-      expect(result.pop(TokenType.WORD).value).to.equal('b*z')
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo' })
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo_bar' })
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'b*z' })
     })
 
     it('detects strings directly following other tokens', function () {
       const result = tokenize('("bar1" foo"bar2" "foo""bar3"')
       expect(result).to.be.an.instanceOf(TokenStream)
-      result.pop(TokenType.PAREN_LEFT)
-      expect(result.pop(TokenType.STRING).value).to.equal('"bar1"')
-      result.pop(TokenType.WORD)
-      expect(result.pop(TokenType.STRING).value).to.equal('"bar2"')
-      result.pop(TokenType.STRING)
-      expect(result.pop(TokenType.STRING).value).to.equal('"bar3"')
+      expect(result.next().type).to.equal(TokenType.PAREN_LEFT)
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"bar1"' })
+      expect(result.next().type).to.equal(TokenType.WORD)
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"bar2"' })
+      expect(result.next().type).to.equal(TokenType.STRING)
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"bar3"' })
     })
 
     it('throws for unterminated strings', function () {
@@ -68,15 +68,55 @@ describe('src/tokenizer/tokenizer.ts', function () {
     it('detects arrows', function () {
       const result = tokenize('->')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.ARROW).value).to.equal('->')
+      expect(result.next()).to.include({ type: TokenType.ARROW, value: '->' })
     })
 
     it('detects arrows between words', function () {
       const result = tokenize('foo->bar')
       expect(result).to.be.an.instanceOf(TokenStream)
-      expect(result.pop(TokenType.WORD).value).to.equal('foo')
-      expect(result.pop(TokenType.ARROW).value).to.equal('->')
-      expect(result.pop(TokenType.WORD).value).to.equal('bar')
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo' })
+      expect(result.next()).to.include({ type: TokenType.ARROW, value: '->' })
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'bar' })
+    })
+
+    it('detects line comments (only input)', function () {
+      const result = tokenize('# line comment')
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '# line comment' })
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('detects line comments (after words)', function () {
+      const result = tokenize('foo # line comment')
+      expect(result.next()).to.include({ type: TokenType.WORD, value: 'foo' })
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '# line comment' })
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('detects line comments (after strings)', function () {
+      const result = tokenize('"foo bar" # line comment')
+      expect(result.next()).to.include({ type: TokenType.STRING, value: '"foo bar"' })
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '# line comment' })
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('detects line comments (multiple consecutive)', function () {
+      const result = tokenize('# line comment\n  #another\n  #yet another')
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '# line comment' })
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '#another' })
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '#yet another' })
+      expect(result.hasNext()).to.be.false
+    })
+
+    it('does not include newline characters in comments', function () {
+      expect(tokenize('# foo\nbar').next()).to.include({ type: TokenType.COMMENT, value: '# foo' })
+      expect(tokenize('# foo\rbar').next()).to.include({ type: TokenType.COMMENT, value: '# foo' })
+      expect(tokenize('# foo\r\nbar').next()).to.include({ type: TokenType.COMMENT, value: '# foo' })
+    })
+
+    it('detects line comments containing # character', function () {
+      const result = tokenize('# foo#bar #')
+      expect(result.next()).to.include({ type: TokenType.COMMENT, value: '# foo#bar #' })
+      expect(result.hasNext()).to.be.false
     })
   })
 })


### PR DESCRIPTION
This PR adds support for line comments (beginning with the hash character `#` at any position, ending at the end of the line).

When the tokenizer encounters a comment, it does not skip it but instead produces a regular token of type `COMMENT`.
This choice was made to allow for pretty-printing to be implemented later.

Skipping comments happens during parsing because only at this point can we be sure that we are not interested in comments.
To that end, parts of `TokenStream` were factored out into a `TokenAccessor` class, which also implements the skipping part.