### PR TITLE
Fix tokenizer allowing newlines in strings

### DIFF
--- a/src/util/find-end-of-line.ts
+++ b/src/util/find-end-of-line.ts
@@ -1,0 +1,19 @@
+/**
+ * Return the index of the next end-of-line character. An end-of-line character is either '\n' or '\r'.
+ * If no such character exists, the line is assumed to end at the string end, and str.length is returned.
+ *
+ *
+ * @param {string} str The subject.
+ * @param {?number} position Optionally, a start index.
+ * @returns {number} The position of the next end-of-line character, or, in absence of one, str.length.
+ */
+export function findEndOfLine (str: string, position?: number): number {
+  const nPos = str.indexOf('\n', position)
+  const rPos = str.indexOf('\r', position)
+
+  return Math.min(
+    str.length,
+    nPos >= 0 ? nPos : str.length,
+    rPos >= 0 ? rPos : str.length
+  )
+}

--- a/test/tokenizer/tokenizer.test.ts
+++ b/test/tokenizer/tokenizer.test.ts
@@ -65,6 +65,12 @@ describe('src/tokenizer/tokenizer.ts', function () {
       expect(() => tokenize('"string" "unterminated string')).to.throw(UnterminatedStringError)
     })
 
+    it('throws for strings broken by newline', function () {
+      expect(() => tokenize('"unterminated\nstring"')).to.throw(UnterminatedStringError)
+      expect(() => tokenize('"unterminated\rstring"')).to.throw(UnterminatedStringError)
+      expect(() => tokenize('"unterminated\r\nstring"')).to.throw(UnterminatedStringError)
+    })
+
     it('detects arrows', function () {
       const result = tokenize('->')
       expect(result).to.be.an.instanceOf(TokenStream)

--- a/test/util/find-end-of-line.test.ts
+++ b/test/util/find-end-of-line.test.ts
@@ -1,0 +1,58 @@
+import { findEndOfLine } from '../../src/util/find-end-of-line'
+
+import { expect } from 'chai'
+
+describe('src/util/regexp-index-of.ts', function () {
+  describe('findEndOfLine() without position', function () {
+    it('returns first position of "\\n"', function () {
+      expect(findEndOfLine('asdf\nghj')).to.equal(4)
+      expect(findEndOfLine('asdf\ngh\nj')).to.equal(4)
+      expect(findEndOfLine('asdf\nghj\n')).to.equal(4)
+    })
+
+    it('returns first position of "\\r"', function () {
+      expect(findEndOfLine('asdf\rghj')).to.equal(4)
+      expect(findEndOfLine('asdf\rgh\rj')).to.equal(4)
+      expect(findEndOfLine('asdf\rghj\r')).to.equal(4)
+    })
+
+    it('returns minimum position if both "\\n" and "\\r" exist', function () {
+      expect(findEndOfLine('a\nsdfghj\rkl')).to.equal(1)
+      expect(findEndOfLine('asd\rfghj\nkl')).to.equal(3)
+    })
+
+    it('returns string.length if no end-of-line exists', function () {
+      expect(findEndOfLine('')).to.equal(0)
+      expect(findEndOfLine('012 456')).to.equal(7)
+    })
+  })
+
+  describe('findEndOfLine() with position', function () {
+    it('returns first position of "\\n" or "\\r"', function () {
+      expect(findEndOfLine('a\nsdf\rghj\nkl', 0)).to.equal(1)
+      expect(findEndOfLine('a\nsdf\rghj\nkl', 1)).to.equal(1)
+      expect(findEndOfLine('a\nsdf\rghj\nkl', 2)).to.equal(5)
+      expect(findEndOfLine('a\nsdf\rghj\nkl', 7)).to.equal(9)
+    })
+
+    it('returns string.length if no end-of-line exists', function () {
+      expect(findEndOfLine('', 0)).to.equal(0)
+      expect(findEndOfLine('ab', 0)).to.equal(2)
+      expect(findEndOfLine('ab', 2)).to.equal(2)
+    })
+  })
+
+  describe('findEndOfLine() with out-of-bounds positions', function () {
+    it('treats negative positions like 0', function () {
+      expect(findEndOfLine('a\nsdfghj\rkl', -1)).to.equal(1)
+      expect(findEndOfLine('asd\rfghj\nkl', -2000)).to.equal(3)
+      expect(findEndOfLine('asdfghjkl', -2000)).to.equal(9)
+    })
+
+    it('treats too large positions like string.length', function () {
+      expect(findEndOfLine('a\nsdfghj\rkl', 100)).to.equal(11)
+      expect(findEndOfLine('asd\rfghj\nkl', 100)).to.equal(11)
+      expect(findEndOfLine('asdfghjkl', 100)).to.equal(9)
+    })
+  })
+})


### PR DESCRIPTION
At the moment, strings could include newline `\n`. For example the following would be a valid string token:

```
"hello 
world"
```

This might be nice in theory, but it makes little sense format-wise. If newline support is to be included in the future it should be explicit, e.g. like so:

```
"hello\n world"
```

This PR disallows the former syntax.