### PR TITLE
Improve TokenAccessor#popOptional()

### DIFF
--- a/src/parser/token-accessor.ts
+++ b/src/parser/token-accessor.ts
@@ -51,14 +51,20 @@ export class TokenAccessor {
   /**
    * Obtain the next token and advance the stream, but only if the token matches the given type.
    * If the type does not match, this returns undefined and the stream does not change state.
+   * Optionally, the token value can be checked in the same manner.
+   *
+   * If no token remains (empty stream), this will return undefined.
    *
    * @param {TokenType} type The type of token to pop off.
+   * @param {?string} value The value the token is expected to have.
    * @returns {Token | undefined} The next token in the stream, or undefined.
-   * @throws {EndOfStreamError} If there is no remaining token.
    */
-  popOptional (type: TokenType): Token | undefined {
+  popOptional (type: TokenType, value?: string): Token | undefined {
+    if (!this.hasNext()) {
+      return undefined
+    }
     const token = this.peek()
-    if (token.type !== type) {
+    if (token.type !== type || (value != null && token.value !== value)) {
       return undefined
     }
     return this.stream.next()
@@ -75,12 +81,9 @@ export class TokenAccessor {
    * @throws {UnexpectedTokenError} If the token type mismatches, or a value was specified and it mismatches.
    */
   pop (type: TokenType, value?: string): Token {
-    const optToken = this.popOptional(type)
+    const optToken = this.popOptional(type, value)
     if (optToken == null) {
-      throw new UnexpectedTokenError(this.peek(), type)
-    }
-    if (value != null && optToken.value !== value) {
-      throw new UnexpectedTokenError(optToken, type, value)
+      throw new UnexpectedTokenError(this.peek(), type, value)
     }
     return optToken
   }

--- a/test/parser/token-accessor.test.ts
+++ b/test/parser/token-accessor.test.ts
@@ -81,17 +81,17 @@ describe('src/parser/token-accessor.ts', function () {
   })
 
   describe('#popOptional()', function () {
-    it('throws an error if called on empty stream', function () {
+    it('returns undefined if called on empty stream', function () {
       const stream = new TokenStream([])
-      expect(() => new TokenAccessor(stream).popOptional(TokenType.WORD)).to.throw()
+      expect(new TokenAccessor(stream).popOptional(TokenType.WORD)).to.be.undefined
     })
 
-    it('throws an error if called on streams containing only skipped tokens', function () {
+    it('returns undefined if called on streams containing only skipped tokens', function () {
       const stream = new TokenStream([
         new Token(TokenType.COMMENT, 0, '#test'),
         new Token(TokenType.COMMENT, 7, '#test')
       ])
-      expect(() => new TokenAccessor(stream, [TokenType.COMMENT]).popOptional(TokenType.COMMENT)).to.throw()
+      expect(new TokenAccessor(stream, [TokenType.COMMENT]).popOptional(TokenType.COMMENT)).to.be.undefined
     })
 
     it('returns undefined when requesting a skipped token', function () {
@@ -111,12 +111,28 @@ describe('src/parser/token-accessor.ts', function () {
       expect(new TokenAccessor(stream).popOptional(TokenType.WORD)).to.equal(tokens[0])
     })
 
+    it('returns token if type and value match', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).popOptional(TokenType.WORD, 'test')).to.equal(tokens[0])
+    })
+
     it('returns undefined if type does not match', function () {
       const tokens = [
         new Token(TokenType.WORD, 0, 'test')
       ]
       const stream = new TokenStream(tokens)
       expect(new TokenAccessor(stream).popOptional(TokenType.PAREN_LEFT)).to.be.undefined
+    })
+
+    it('returns undefined if type matches, but value does not', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, 'test')
+      ]
+      const stream = new TokenStream(tokens)
+      expect(new TokenAccessor(stream).popOptional(TokenType.WORD, 'foo')).to.be.undefined
     })
 
     it('advances the stream, but only on a match', function () {


### PR DESCRIPTION
This PR enables `TokenAccessor#popOptional()` to check for value in addition to type.
Also, `popOptional()` simply returns `undefined` on empty streams instead of throwing an error.
This should be more in line with the expected behavior for that interface.