### PR TITLE
Implement message parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,124 @@ object(actor) bar = "Bar"
 This will create one _component object_ with id `foo` and label `Foo`,
 as well as one _actor object_ with id `bar` and label `Bar`.
 
+The object types differ in the way they are presented:
+Components are drawn as boxes, while actors are drawn as stick figures.
+
+### Messages
+
+Messages (or activations) are written as arrows. Most types of messages can
+have other messages as children, i.e., functions calling other functions.
+For an object to send a message, it has to be _active_.
+An object is active for the duration it takes to handle a message.
+Initially, no object is active.
+A _found message_ (message from the outside) can activate an object initially.
+Afterwards, more messages can follow.
+For example:
+
+```
+object foo = "Foo"
+object bar = "Bar"
+
+*->foo "a found message targeting foo" {
+  ->bar "a message from foo to bar"
+  ->foo "a message from foo to itself"
+  ->bar {
+    ->foo
+  }
+}
+
+*->bar
+*->bar {}
+```
+
+The above script defines two objects `foo` and `bar`.
+Then there is a found message activating `foo` and a few nested messages on
+multiple levels.
+Note that labels are entirely optional, as are the braces (`{`, `}`) in case
+there are no nested messages.
+
+**Message types**
+
+There are _found messages_ from the outside to an object, regular messages
+between two objects, and _lost messages_ from an object to the outside.
+Lost messages are specified as in the following example:
+
+```
+object foo = "Foo"
+object bar = "Bar"
+
+*->foo "foo is activated" {
+  ->* "this message is leaving foo"
+}
+```
+
+Again, the label is optional.
+Lost messages cannot have a block (as there is no execution context).
+
+Regular messages have different types as well.
+By default, they are synchronous.
+By specifying `async`, `create` or `destroy` the type of message can be
+changed:
+
+```
+object foo = "Foo"
+object bar = "Bar"
+
+*->foo {
+  ->(create) bar "this message creates bar"
+  ->(async) bar "this is an asynchronous message" {
+    ->foo "it can contain other messages"
+    ->(async) foo "they can be of any type"
+  }
+  ->(destroy) bar "this message destroys bar"
+}
+```
+
+Asynchronous messages, like synchronous messages, can have children.
+`create` and `destroy` messages cannot.
+If you want to be explicit about a message's synchronicity, you can specify
+its type as `sync`, e.g., `->(sync) bar`, though this is not required.
+
+Note that `create` and `destroy` will have a special effect on object
+positioning inside the diagram and on the length of its lifeline.
+
+**Return values**
+
+By default, reply messages are automatically created for synchronous messages.
+To specify the reply message label, use a `return` statement:
+
+```
+object foo = "Foo"
+object bar = "Bar"
+
+*->foo {
+  ->bar "message" {
+    return "reply"
+  }
+}
+```
+
+The above will set the reply message label to read `reply`.
+
+Asynchronous messages do not include a reply by default.
+Mostly, it makes no sense to include one, either.
+Instead, an explicit second asynchronous message can serve as callback.
+To specify a reply regardless, the same syntax can be used:
+
+```
+object foo = "Foo"
+object bar = "Bar"
+
+*->foo {
+  ->(async) bar "async message" {
+    return "with a reply"
+  }
+}
+```
+
+No other type of message (lost, found, `create`, `destroy`) may have a
+`return` statement.
+
 ### Comments
 
 Comments can be used to include notes in the Lifeline script that should not

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run clean && tsc",
     "lint": "eslint --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ignore-path .gitignore .",
-    "test": "npm run clean && ts-mocha --recursive test/**/*.test.*",
+    "test": "npm run clean && ts-mocha --recursive \"test/**/*.test.*\"",
     "coverage": "nyc --reporter=lcov npm test",
     "prepare": "npm run build"
   },

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -54,3 +54,48 @@ export class DuplicateOptionError extends ParserError {
     super(token, `duplicate option ${option}`)
   }
 }
+
+/**
+ * Thrown when a message block is specified for a message that cannot have one.
+ */
+export class UnexpectedMessageBlockError extends ParserError {
+  constructor (token: Token) {
+    super(token, 'this message type cannot have a message block')
+  }
+}
+
+/**
+ * Thrown when a message requires a target entity to be specified but none was given.
+ */
+export class MissingTargetError extends ParserError {
+  constructor (token: Token) {
+    super(token, 'expected object target for this message')
+  }
+}
+
+/**
+ * Thrown when an entity is referenced that was not defined.
+ */
+export class UnknownObjectError extends ParserError {
+  constructor (token: Token, objectId: string) {
+    super(token, `object "${objectId}" not defined`)
+  }
+}
+
+/**
+ * Thrown when a message block was already returned from, yet there is more code in it.
+ */
+export class AlreadyReturnedError extends ParserError {
+  constructor (token: Token) {
+    super(token, 'there cannot be any code after a return statement')
+  }
+}
+
+/**
+ * Thrown when a return value is specified on a message that cannot have one.
+ */
+export class UnsupportedReturnError extends ParserError {
+  constructor (token: Token) {
+    super(token, 'return is not supported on this message')
+  }
+}

--- a/src/parser/message/message-description.ts
+++ b/src/parser/message/message-description.ts
@@ -1,0 +1,51 @@
+import { Entity } from '../../sequence/entity'
+import { Token } from '../../tokenizer/token'
+import { Activation } from '../../sequence/activation'
+
+/**
+ * The script can specify a message "type", which is a subset of MessageStyle.
+ * This does not include things such as found messages / lost messages, those are detected by other means and hence
+ * not included in this enum.
+ */
+export enum MessageType {
+  SYNC,
+  ASYNC,
+  CREATE,
+  DESTROY
+}
+
+/**
+ * A message description is a complete representation of a message (including a block, if one is present).
+ * This does not differentiate between message species but simply states everything as it appears in the script.
+ * Message descriptions contain "evidence" for each property (= the tokens causing that property to have its value).
+ */
+export interface MessageDescription {
+  type: MessageType
+  fromOutside: boolean
+  target: Entity | undefined
+  label: string
+  block: MessageBlock | undefined
+
+  evidence: {
+    type: Token
+    fromOutside: Token
+    target: Token
+    label: Token
+    block: Token
+  }
+}
+
+/**
+ * A message block is the part of a message description that contains child messages.
+ * As such, it stores a list of activations and potentially a return value.
+ * Evidence will be included for the latter (to enable throwing an error if a return value was provided when none is
+ * allowed, or if one was not provided where it is required).
+ */
+export interface MessageBlock {
+  activations: Activation[]
+  returnValue: string | undefined
+
+  evidence: {
+    returnValue: Token
+  }
+}

--- a/src/parser/message/parse-message-block.ts
+++ b/src/parser/message/parse-message-block.ts
@@ -9,6 +9,43 @@ import { TokenAccessor } from '../token-accessor'
 import { MessageBlock } from './message-description'
 
 /**
+ * This class helps construct a MessageBlock from activations and a return value.
+ * Note that invocation order is important; there cannot be any further activations added after a return value was set.
+ */
+class MessageBlockBuilder {
+  private readonly activations: Activation[] = []
+  private returnValue: string | undefined
+  private returnEvidence: Token | undefined
+
+  private ensureNotReturned (evidence: Token): void {
+    if (this.returnValue != null) {
+      throw new AlreadyReturnedError(evidence)
+    }
+  }
+
+  applyReturn (value: string, evidence: Token): void {
+    this.ensureNotReturned(evidence)
+    this.returnValue = value
+    this.returnEvidence = evidence
+  }
+
+  addActivation (activation: Activation, evidence: Token): void {
+    this.ensureNotReturned(evidence)
+    this.activations.push(activation)
+  }
+
+  build (blockClose: Token): MessageBlock {
+    return {
+      activations: this.activations,
+      returnValue: this.returnValue,
+      evidence: {
+        returnValue: this.returnEvidence ?? blockClose
+      }
+    }
+  }
+}
+
+/**
  * Determine whether the given token marks the beginning of a message block.
  * This will only produce valid results when right at the end of a message description.
  *
@@ -36,34 +73,19 @@ export function detectMessageBlock (token: Token): boolean {
 export function parseMessageBlock (tokens: TokenAccessor, entities: EntityLookup, active: Entity): MessageBlock {
   tokens.pop(TokenType.BLOCK_LEFT)
 
-  const activations: Activation[] = []
-
-  let returnValue: string | undefined
-  let tReturn: Token | undefined
+  const builder = new MessageBlockBuilder()
 
   let tBlockRight
   while ((tBlockRight = tokens.popOptional(TokenType.BLOCK_RIGHT)) == null) {
     const token = tokens.peek()
-    if (returnValue != null) {
-      throw new AlreadyReturnedError(token)
-    }
     if (detectMessage(token)) {
-      activations.push(parseMessage(tokens, entities, active))
-      continue
+      builder.addActivation(parseMessage(tokens, entities, active), token)
+    } else if (detectReturn(token)) {
+      builder.applyReturn(parseReturn(tokens), token)
+    } else {
+      throw new UnexpectedTokenError(token)
     }
-    if (detectReturn(token)) {
-      returnValue = parseReturn(tokens)
-      tReturn = token
-      continue
-    }
-    throw new UnexpectedTokenError(token)
   }
 
-  return {
-    activations,
-    returnValue,
-    evidence: {
-      returnValue: tReturn ?? tBlockRight
-    }
-  }
+  return builder.build(tBlockRight)
 }

--- a/src/parser/message/parse-message-block.ts
+++ b/src/parser/message/parse-message-block.ts
@@ -1,0 +1,69 @@
+import { Entity } from '../../sequence/entity'
+import { Token, TokenType } from '../../tokenizer/token'
+import { Activation } from '../../sequence/activation'
+import { AlreadyReturnedError, UnexpectedTokenError } from '../errors'
+import { detectMessage, parseMessage } from './parse-message'
+import { detectReturn, parseReturn } from './parse-return'
+import { EntityLookup } from '../parser-state'
+import { TokenAccessor } from '../token-accessor'
+import { MessageBlock } from './message-description'
+
+/**
+ * Determine whether the given token marks the beginning of a message block.
+ * This will only produce valid results when right at the end of a message description.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token (and what follows) could be parsed as a message block.
+ */
+export function detectMessageBlock (token: Token): boolean {
+  return token.type === TokenType.BLOCK_LEFT
+}
+
+/**
+ * Force-parse a message block.
+ * This requires the message to have a target entity.
+ *
+ * Message blocks can include return statements. This function does not care whether return statements are allowed
+ * for the specific message type. It does, however, include "evidence" (a token) for the return value if one exists so
+ * meaningful error messages can be created later.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @param {EntityLookup} entities A way of resolving entity ids.
+ * @param {Entity} active The entity that was targeted by the message to which this block belongs.
+ * @returns {object} The parsed message description.
+ * @throws {ParserError} If a check fails.
+ */
+export function parseMessageBlock (tokens: TokenAccessor, entities: EntityLookup, active: Entity): MessageBlock {
+  tokens.pop(TokenType.BLOCK_LEFT)
+
+  const activations: Activation[] = []
+
+  let returnValue: string | undefined
+  let tReturn: Token | undefined
+
+  let tBlockRight
+  while ((tBlockRight = tokens.popOptional(TokenType.BLOCK_RIGHT)) == null) {
+    const token = tokens.peek()
+    if (returnValue != null) {
+      throw new AlreadyReturnedError(token)
+    }
+    if (detectMessage(token)) {
+      activations.push(parseMessage(tokens, entities, active))
+      continue
+    }
+    if (detectReturn(token)) {
+      returnValue = parseReturn(tokens)
+      tReturn = token
+      continue
+    }
+    throw new UnexpectedTokenError(token)
+  }
+
+  return {
+    activations,
+    returnValue,
+    evidence: {
+      returnValue: tReturn ?? tBlockRight
+    }
+  }
+}

--- a/src/parser/message/parse-message-description.ts
+++ b/src/parser/message/parse-message-description.ts
@@ -1,0 +1,173 @@
+import { Token, TokenType } from '../../tokenizer/token'
+import { MissingTargetError, UnexpectedMessageBlockError, UnknownObjectError, UnsupportedOptionError } from '../errors'
+import { EntityLookup } from '../parser-state'
+import { unquote } from '../unquote'
+import { detectMessageBlock, parseMessageBlock } from './parse-message-block'
+import { MessageBlock, MessageDescription, MessageType } from './message-description'
+import { TokenAccessor } from '../token-accessor'
+import { keywords, messageOptions } from '../strings'
+import { Entity } from '../../sequence/entity'
+
+// I wish Object.values was supported in this ES version
+const AVAILABLE_TYPE_KEYWORDS = Object.keys(messageOptions).map(key => (messageOptions as Record<string, string>)[key])
+
+const TYPE_OPTIONS: ReadonlyMap<string, MessageType> = new Map([
+  [messageOptions.sync, MessageType.SYNC],
+  [messageOptions.async, MessageType.ASYNC],
+  [messageOptions.create, MessageType.CREATE],
+  [messageOptions.destroy, MessageType.DESTROY]
+])
+
+interface OptionalValueWithEvidence<T> {
+  value: T | undefined
+  evidence: Token | undefined
+}
+
+/**
+ * Determine whether the message begins with '*'. If yes, value will be true, and false otherwise.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @returns {object} The Boolean value and evidence for it if possible.
+ */
+function determineFromOutside (tokens: TokenAccessor): OptionalValueWithEvidence<boolean> {
+  const evidence = tokens.popOptional(TokenType.WORD, keywords.outside)
+  return { value: evidence != null, evidence }
+}
+
+/**
+ * Determine the type of message (sync, async, ...) specified in parentheses.
+ * If no type was specified, value will be undefined.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @returns {object} The message type and evidence for it if possible.
+ */
+function determineType (tokens: TokenAccessor): OptionalValueWithEvidence<MessageType> {
+  if (tokens.popOptional(TokenType.PAREN_LEFT) != null) {
+    const evidence = tokens.pop(TokenType.WORD)
+    const type = TYPE_OPTIONS.get(evidence.value)
+    if (type == null) {
+      throw new UnsupportedOptionError(evidence, evidence.value, AVAILABLE_TYPE_KEYWORDS)
+    }
+    tokens.pop(TokenType.PAREN_RIGHT)
+    return { value: type, evidence }
+  }
+  return { value: undefined, evidence: undefined }
+}
+
+/**
+ * Determine the message target. This will be an entity if one was specified, and undefined if '*' was given.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @param {EntityLookup} entities A way of resolving entity ids.
+ * @returns {object} The target and evidence for it if possible.
+ */
+function determineTarget (tokens: TokenAccessor, entities: EntityLookup): OptionalValueWithEvidence<Entity> {
+  const evidence = tokens.pop(TokenType.WORD)
+  if (evidence.value === keywords.outside) {
+    return { value: undefined, evidence }
+  }
+  const entity = entities.lookupEntity(evidence.value)
+  if (entity == null) {
+    throw new UnknownObjectError(evidence, evidence.value)
+  }
+  return { value: entity, evidence }
+}
+
+/**
+ * Determine the message label. If no label was specified, the value will be undefined.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @returns {object} The message label and evidence for it if possible.
+ */
+function determineLabel (tokens: TokenAccessor): OptionalValueWithEvidence<string> {
+  const evidence = tokens.popOptional(TokenType.STRING)
+  if (evidence == null) {
+    return { value: undefined, evidence }
+  }
+  return { value: unquote(evidence).trim(), evidence }
+}
+
+/**
+ * Determine the message block (nested messages). If no block exists, the value will be undefined.
+ * If a block exists but the target is null, this will throw an error.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @param {EntityLookup} entities A way of resolving entity ids.
+ * @param {Entity | undefined} target The already-resolved message target.
+ * @returns {object} The message label and evidence for it if possible.
+ */
+function determineBlock (tokens: TokenAccessor, entities: EntityLookup, target: Entity | undefined): OptionalValueWithEvidence<MessageBlock> {
+  const evidence = tokens.hasNext() ? tokens.peek() : undefined
+  if (evidence == null || !detectMessageBlock(evidence)) {
+    return { value: undefined, evidence }
+  }
+  if (target == null) {
+    throw new UnexpectedMessageBlockError(tokens.peek())
+  }
+  return { value: parseMessageBlock(tokens, entities, target), evidence }
+}
+
+/**
+ * Determine whether the given token marks the beginning of a message description.
+ * This will only produce valid results when on global level or inside a message block.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token (and what follows) could be parsed as a message description.
+ */
+export function detectMessageDescription (token: Token): boolean {
+  return token.type === TokenType.ARROW || (token.type === TokenType.WORD && token.value === keywords.outside)
+}
+
+/**
+ * Parse a message description (complete representation of a message), including basic checks but not much more.
+ * The checks that are done include: entities must exist if named, message type must be valid if specified,
+ * a message block requires the message to have a target entity, etc.
+ * No checks are done regarding semantic correctness (can that type of message exist at this point in the script?).
+ *
+ * For each value in the description (whether it exists or not) a piece of "evidence" will be returned as well.
+ * This is the token that caused that value to be detected (or not to be detected) and allows for meaningful error
+ * messages to be created later.
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @param {EntityLookup} entities A way of resolving entity ids.
+ * @returns {object} The parsed message description.
+ * @throws {ParserError} If a check fails.
+ */
+export function parseMessageDescription (tokens: TokenAccessor, entities: EntityLookup): MessageDescription {
+  // parse the following format, where [...] indicates optionality and target is an entity or '*':
+  // [*] -> [( [type] )] target ["label"] [{ block }]
+
+  const { value: fromOutside, evidence: fromOutsideEvidence } = determineFromOutside(tokens)
+
+  const tArrow = tokens.pop(TokenType.ARROW)
+
+  const { value: type, evidence: typeEvidence } = determineType(tokens)
+  const { value: target, evidence: targetEvidence } = determineTarget(tokens, entities)
+
+  // Catch messages of the form '*->*'.
+  // If this check was not done here, the problem _would_ be detected, but only much later and potentially with
+  // a more cryptic error message.
+  // In particular, due to how determineBlock() works, '*->* {}' would lead to an error because a block cannot exist
+  // when there is no target -- but in reality the problem _really_ comes from a missing target!
+  if (fromOutside === true && target == null) {
+    throw new MissingTargetError(targetEvidence ?? tArrow)
+  }
+
+  const { value: label, evidence: labelEvidence } = determineLabel(tokens)
+  const { value: block, evidence: blockEvidence } = determineBlock(tokens, entities, target)
+
+  return {
+    type: type ?? MessageType.SYNC,
+    fromOutside: fromOutside ?? false,
+    target,
+    label: label ?? '',
+    block,
+    evidence: {
+      type: typeEvidence ?? tArrow,
+      fromOutside: fromOutsideEvidence ?? tArrow,
+      target: targetEvidence ?? tArrow,
+      label: labelEvidence ?? tArrow,
+      block: blockEvidence ?? tArrow
+    }
+  }
+}

--- a/src/parser/message/parse-message.ts
+++ b/src/parser/message/parse-message.ts
@@ -1,0 +1,56 @@
+import { Entity } from '../../sequence/entity'
+import { Activation } from '../../sequence/activation'
+import { Token } from '../../tokenizer/token'
+import { UnexpectedTokenError } from '../errors'
+import { EntityLookup } from '../parser-state'
+import { detectMessageDescription, parseMessageDescription } from './parse-message-description'
+import { TokenAccessor } from '../token-accessor'
+import { matchFoundMessage } from './species/match-found-message'
+import { matchLostMessage } from './species/match-lost-message'
+import { matchRegularMessage } from './species/match-regular-message'
+
+/**
+ * Determine whether the given token marks the beginning of a message.
+ * This will only produce valid results when on global level or inside a message block.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token (and what follows) could be parsed as a message.
+ */
+export function detectMessage (token: Token): boolean {
+  return detectMessageDescription(token)
+}
+
+/**
+ * Force-parse a message including full validity and type checks.
+ * This can parse found messages, lost messages, and regular messages (with two participating entities).
+ *
+ * @param {TokenAccessor} tokens The token stream.
+ * @param {EntityLookup} entities A way of resolving entity ids.
+ * @param {Entity | undefined} active The entity that was targeted by the parent message, if any.
+ * @returns {object} The parsed message description.
+ * @throws {ParserError} If a check fails.
+ */
+export function parseMessage (tokens: TokenAccessor, entities: EntityLookup, active: Entity | undefined): Activation {
+  /*
+   * Parsing messages works in multiple layers because a few different syntactical forms are supported.
+   * First, every piece of information about the message is gathered as the "message description".
+   * This step does not try to make sense of any of it and poses little to no conditions on the input,
+   * except for things like "if an entity is named, it must exist".
+   * Then in the second step, a sort of pattern-matching is done on that message description to determine which
+   * "species" of message it belongs to.
+   * If one of the species matches, it will produce an Activation.
+   */
+
+  const desc = parseMessageDescription(tokens, entities)
+
+  const activation = matchFoundMessage(desc) ??
+    matchLostMessage(desc, active) ??
+    matchRegularMessage(desc, active)
+
+  if (activation == null) {
+    // no species produced a match, this is most likely due to invalid target
+    throw new UnexpectedTokenError(desc.evidence.target)
+  }
+
+  return activation
+}

--- a/src/parser/message/parse-return.ts
+++ b/src/parser/message/parse-return.ts
@@ -1,0 +1,27 @@
+import { Token, TokenType } from '../../tokenizer/token'
+import { keywords } from '../strings'
+import { unquote } from '../unquote'
+import { TokenAccessor } from '../token-accessor'
+
+/**
+ * Determine whether the given token marks the beginning of a return statement.
+ * This will only produce valid results when inside a message block.
+ *
+ * @param {Token} token The next token in the input stream.
+ * @returns {boolean} Whether the token (and what follows) could be parsed as a return statement.
+ */
+export function detectReturn (token: Token): boolean {
+  return token.type === TokenType.WORD && token.value === keywords.return
+}
+
+/**
+ * Force-parse a return statement from the given stream.
+ *
+ * @param {TokenAccessor} tokens The input stream.
+ * @returns {string} The return value.
+ */
+export function parseReturn (tokens: TokenAccessor): string {
+  tokens.pop(TokenType.WORD, keywords.return)
+  const tValue = tokens.pop(TokenType.STRING)
+  return unquote(tValue).trim()
+}

--- a/src/parser/message/species/match-found-message.ts
+++ b/src/parser/message/species/match-found-message.ts
@@ -1,0 +1,34 @@
+import { MessageDescription, MessageType } from '../message-description'
+import { MissingTargetError, UnsupportedOptionError, UnsupportedReturnError } from '../../errors'
+import { messageOptions } from '../../strings'
+import { Activation } from '../../../sequence/activation'
+import { FoundMessage } from '../../../sequence/message'
+
+/**
+ * Try to match a "found message" from the given description.
+ * This will match exactly iff the message comes from the outside.
+ * Errors will be thrown if further constraints are violated.
+ * If it does not match (message has no source or has a target), undefined will be returned.
+ *
+ * @param {object} desc The message description to match.
+ * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ */
+export function matchFoundMessage (desc: MessageDescription): Activation | undefined {
+  const { type, fromOutside, target, label, block, evidence } = desc
+  if (!fromOutside) {
+    return undefined
+  }
+
+  if (type !== MessageType.SYNC) {
+    throw new UnsupportedOptionError(evidence.type, evidence.type.value, [messageOptions.sync])
+  }
+  if (target == null) {
+    throw new MissingTargetError(evidence.target)
+  }
+  if (block?.returnValue != null) {
+    throw new UnsupportedReturnError(block.evidence.returnValue)
+  }
+
+  const msg = new FoundMessage(target, label)
+  return new Activation(msg, undefined, block?.activations ?? [])
+}

--- a/src/parser/message/species/match-lost-message.ts
+++ b/src/parser/message/species/match-lost-message.ts
@@ -1,0 +1,36 @@
+import { MessageDescription, MessageType } from '../message-description'
+import { UnexpectedMessageBlockError, UnexpectedTokenError, UnsupportedOptionError } from '../../errors'
+import { Activation } from '../../../sequence/activation'
+import { LostMessage } from '../../../sequence/message'
+import { Entity } from '../../../sequence/entity'
+import { messageOptions } from '../../strings'
+
+/**
+ * Try to match a "lost message" from the given description.
+ * This will match exactly iff the message does not come from the outside AND it does not have a target.
+ * Errors will be thrown if further constraints are violated.
+ * If it does not match (message has no source or has a target), undefined will be returned.
+ *
+ * @param {object} desc The message description to match.
+ * @param {Entity} active The entity that is the target of the parent message, if any.
+ * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ */
+export function matchLostMessage (desc: MessageDescription, active: Entity | undefined): Activation | undefined {
+  const { type, fromOutside, target, label, block, evidence } = desc
+  if (fromOutside || target != null) {
+    return undefined
+  }
+
+  if (type !== MessageType.SYNC) {
+    throw new UnsupportedOptionError(evidence.type, evidence.type.value, [messageOptions.sync])
+  }
+  if (active == null) {
+    throw new UnexpectedTokenError(evidence.fromOutside)
+  }
+  if (block != null) {
+    throw new UnexpectedMessageBlockError(evidence.block)
+  }
+
+  const msg = new LostMessage(active, label)
+  return new Activation(msg, undefined, [])
+}

--- a/src/parser/message/species/match-regular-message.ts
+++ b/src/parser/message/species/match-regular-message.ts
@@ -1,0 +1,108 @@
+import { MessageBlock, MessageDescription, MessageType } from '../message-description'
+import { UnexpectedMessageBlockError, UnexpectedTokenError } from '../../errors'
+import { Activation } from '../../../sequence/activation'
+import { AsyncMessage, CreateMessage, DestroyMessage, ReplyMessage, SyncMessage } from '../../../sequence/message'
+import { Entity } from '../../../sequence/entity'
+
+const DEFAULT_CREATE_MESSAGE = '«create»'
+const DEFAULT_DESTROY_MESSAGE = '«destroy»'
+
+interface ActivationConstructor {
+  allowBlock: boolean
+  construct: (active: Entity, target: Entity, label: string, block?: MessageBlock) => Activation
+}
+
+// constructor for SYNC messages
+const syncConstructor: ActivationConstructor = {
+  allowBlock: true,
+  construct (active: Entity, target: Entity, label: string, block?: MessageBlock): Activation {
+    const msg = new SyncMessage(active, target, label)
+    // do not include a reply for self-calls unless they have an explicit return value
+    const reply = target.id !== active.id || block?.returnValue != null
+      ? new ReplyMessage(target, active, block?.returnValue ?? '')
+      : undefined
+    return new Activation(msg, reply, block?.activations ?? [])
+  }
+}
+
+// constructor for ASYNC messages
+const asyncConstructor: ActivationConstructor = {
+  allowBlock: true,
+  construct (active: Entity, target: Entity, label: string, block?: MessageBlock): Activation {
+    const msg = new AsyncMessage(active, target, label)
+    // do not include a reply for async unless they have an explicit return value
+    const reply = block?.returnValue != null
+      ? new ReplyMessage(target, active, block?.returnValue ?? '')
+      : undefined
+    return new Activation(msg, reply, block?.activations ?? [])
+  }
+}
+
+// constructor for CREATE messages
+const createConstructor: ActivationConstructor = {
+  allowBlock: false,
+  construct (active: Entity, target: Entity, label: string): Activation {
+    const msg = new CreateMessage(active, target, label !== '' ? label : DEFAULT_CREATE_MESSAGE)
+    return new Activation(msg, undefined, [])
+  }
+}
+
+// constructor for DESTROY messages
+const destroyConstructor: ActivationConstructor = {
+  allowBlock: false,
+  construct (active: Entity, target: Entity, label: string): Activation {
+    const msg = new DestroyMessage(active, target, label !== '' ? label : DEFAULT_DESTROY_MESSAGE)
+    return new Activation(msg, undefined, [])
+  }
+}
+
+/**
+ * Depending on the message type, activations have to be created differently.
+ * This function chooses the correct constructor for the given type.
+ *
+ * @param {MessageType} messageType The message type.
+ * @returns {object} The constructor for that type.
+ */
+function lookupConstructor (messageType: MessageType): ActivationConstructor {
+  // this switch is complete, otherwise TypeScript would complain
+  switch (messageType) {
+    case MessageType.SYNC:
+      return syncConstructor
+    case MessageType.ASYNC:
+      return asyncConstructor
+    case MessageType.CREATE:
+      return createConstructor
+    case MessageType.DESTROY:
+      return destroyConstructor
+  }
+}
+
+/**
+ * Try to match a "regular message" (message having two participating entities) from the given description.
+ * This will match exactly iff the message does not come from the outside AND it has a target.
+ * Errors will be thrown if further constraints are violated.
+ * If it does not match (message has no source or no target), undefined will be returned.
+ *
+ * @param {object} desc The message description to match.
+ * @param {Entity} active The entity that is the target of the parent message, if any.
+ * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ */
+export function matchRegularMessage (desc: MessageDescription, active: Entity | undefined): Activation | undefined {
+  const { type, fromOutside, target, label, block, evidence } = desc
+  // message is "regular" iff it has both source and target
+  if (fromOutside || target == null) {
+    return undefined
+  }
+
+  // since the message does not come from the outside, expect a source to be active
+  if (active == null) {
+    throw new UnexpectedTokenError(evidence.fromOutside)
+  }
+
+  // find the appropriate constructor for the type of message (sync, async, ...)
+  const constructor = lookupConstructor(type)
+  if (!constructor.allowBlock && block != null) {
+    throw new UnexpectedMessageBlockError(evidence.block)
+  }
+  return constructor.construct(active, target, label, block)
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -5,6 +5,7 @@ import { detectEntity, parseEntity } from './entity/parse-entity'
 import { UnexpectedTokenError } from './errors'
 import { TokenAccessor } from './token-accessor'
 import { TokenType } from '../tokenizer/token'
+import { detectMessage, parseMessage } from './message/parse-message'
 
 /**
  * Parse the given stream of tokens into a sequence.
@@ -20,10 +21,16 @@ export function parse (tokens: TokenStream): Sequence {
 
   const accessor = new TokenAccessor(tokens, [TokenType.COMMENT])
 
+  // On global level, the script can contain either entity definitions or messages.
+
   while (accessor.hasNext()) {
     const token = tokens.peek()
     if (detectEntity(token)) {
       state.insertEntity(parseEntity(accessor))
+      continue
+    }
+    if (detectMessage(token)) {
+      state.insertActivation(parseMessage(accessor, state, undefined))
       continue
     }
     throw new UnexpectedTokenError(token)

--- a/src/parser/strings.ts
+++ b/src/parser/strings.ts
@@ -3,7 +3,8 @@
  */
 export const keywords = {
   object: 'object',
-  outside: '*'
+  outside: '*',
+  return: 'return'
 }
 
 /**
@@ -11,4 +12,14 @@ export const keywords = {
  */
 export const entityOptions = {
   actor: 'actor'
+}
+
+/**
+ * Available options when specifying a regular message (not found message).
+ */
+export const messageOptions = {
+  sync: 'sync',
+  async: 'async',
+  create: 'create',
+  destroy: 'destroy'
 }

--- a/test/parser/message/parse-message-block.test.ts
+++ b/test/parser/message/parse-message-block.test.ts
@@ -1,0 +1,126 @@
+import { detectMessageBlock, parseMessageBlock } from '../../../src/parser/message/parse-message-block'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
+import { ParserError } from '../../../src/parser/errors'
+import { Entity, EntityType } from '../../../src/sequence/entity'
+import { EntityLookup } from '../../../src/parser/parser-state'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/parse-message-block.ts', function () {
+  describe('detectMessageBlock()', function () {
+    it('returns true if given block_left', function () {
+      const token = new Token(TokenType.BLOCK_LEFT, 0, '{')
+      expect(detectMessageBlock(token)).to.be.true
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.STRING, 0, '"{"')
+      expect(detectMessageBlock(token)).to.be.false
+    })
+  })
+
+  describe('parseMessageBlock()', function () {
+    const foo = new Entity(EntityType.COMPONENT, 'foo', 'Foo')
+    const bar = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+    const entityLookup: EntityLookup = {
+      lookupEntity (id: string): Entity | undefined {
+        return id === foo.id ? foo : (id === bar.id ? bar : undefined)
+      }
+    }
+
+    it('parses empty block', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.BLOCK_RIGHT, 1, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageBlock(tokenAccessor, entityLookup, foo)
+      expect(parsed).to.deep.equal({
+        activations: [],
+        returnValue: undefined,
+        evidence: {
+          returnValue: tokens[1]
+        }
+      })
+    })
+
+    it('parses block with child messages', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.ARROW, 10, '->'),
+        new Token(TokenType.WORD, 20, 'foo'),
+        new Token(TokenType.ARROW, 10, '->'),
+        new Token(TokenType.WORD, 20, 'bar'),
+        new Token(TokenType.WORD, 30, '*'),
+        new Token(TokenType.ARROW, 40, '->'),
+        new Token(TokenType.WORD, 50, 'bar'),
+        new Token(TokenType.BLOCK_RIGHT, 60, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageBlock(tokenAccessor, entityLookup, foo)
+      expect(parsed.activations).to.have.lengthOf(3)
+      expect(parsed.activations[0].message.from).to.equal(foo)
+      expect(parsed.activations[0].message.to).to.equal(foo)
+      expect(parsed.activations[1].message.from).to.equal(foo)
+      expect(parsed.activations[1].message.to).to.equal(bar)
+      expect(parsed.activations[2].message.from).to.be.undefined
+      expect(parsed.activations[2].message.to).to.equal(bar)
+      expect(parsed.returnValue).to.be.undefined
+    })
+
+    it('parses block with return statement', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.WORD, 10, 'return'),
+        new Token(TokenType.STRING, 20, '"foo"'),
+        new Token(TokenType.BLOCK_RIGHT, 30, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageBlock(tokenAccessor, entityLookup, foo)
+      expect(parsed).to.deep.equal({
+        activations: [],
+        returnValue: 'foo',
+        evidence: {
+          returnValue: tokens[1]
+        }
+      })
+    })
+
+    it('throws for multiple return statements', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.WORD, 10, 'return'),
+        new Token(TokenType.STRING, 20, '"foo"'),
+        new Token(TokenType.WORD, 10, 'return'),
+        new Token(TokenType.STRING, 20, '"bar"'),
+        new Token(TokenType.BLOCK_RIGHT, 30, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageBlock(tokenAccessor, entityLookup, foo)).to.throw(ParserError)
+    })
+
+    it('throws for message after return statement', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.WORD, 10, 'return'),
+        new Token(TokenType.STRING, 20, '"foo"'),
+        new Token(TokenType.WORD, 10, '->bar'),
+        new Token(TokenType.BLOCK_RIGHT, 30, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageBlock(tokenAccessor, entityLookup, foo)).to.throw(ParserError)
+    })
+
+    it('throws for invalid token', function () {
+      const tokens = [
+        new Token(TokenType.BLOCK_LEFT, 0, '{'),
+        new Token(TokenType.WORD, 10, 'asdf'),
+        new Token(TokenType.BLOCK_RIGHT, 30, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageBlock(tokenAccessor, entityLookup, foo)).to.throw(ParserError)
+    })
+  })
+})

--- a/test/parser/message/parse-message-description.test.ts
+++ b/test/parser/message/parse-message-description.test.ts
@@ -1,0 +1,220 @@
+import { detectMessageDescription, parseMessageDescription } from '../../../src/parser/message/parse-message-description'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
+import { Entity, EntityType } from '../../../src/sequence/entity'
+import { EntityLookup } from '../../../src/parser/parser-state'
+import { MessageBlock, MessageType } from '../../../src/parser/message/message-description'
+import { ParserError } from '../../../src/parser/errors'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/parse-message-description.ts', function () {
+  describe('detectMessageDescription()', function () {
+    it('returns true if given arrow', function () {
+      const token = new Token(TokenType.ARROW, 0, '->')
+      expect(detectMessageDescription(token)).to.be.true
+    })
+
+    it('returns true if given "*"', function () {
+      const token = new Token(TokenType.WORD, 0, '*')
+      expect(detectMessageDescription(token)).to.be.true
+    })
+
+    it('returns false if given a different word', function () {
+      const token = new Token(TokenType.WORD, 0, '**')
+      expect(detectMessageDescription(token)).to.be.false
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.STRING, 0, '"->"')
+      expect(detectMessageDescription(token)).to.be.false
+    })
+  })
+
+  describe('parseMessageDescription()', function () {
+    const foo = new Entity(EntityType.COMPONENT, 'foo', 'Foo')
+    const bar = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+    const entityLookup: EntityLookup = {
+      lookupEntity (id: string): Entity | undefined {
+        return id === foo.id ? foo : (id === bar.id ? bar : undefined)
+      }
+    }
+
+    it('parses found message', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, '*'),
+        new Token(TokenType.ARROW, 1, '->'),
+        new Token(TokenType.WORD, 3, 'foo')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.SYNC,
+        fromOutside: true,
+        target: foo,
+        label: '',
+        block: undefined
+      })
+    })
+
+    it('parses found message with label', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, '*'),
+        new Token(TokenType.ARROW, 1, '->'),
+        new Token(TokenType.WORD, 3, 'foo'),
+        new Token(TokenType.STRING, 6, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.SYNC,
+        fromOutside: true,
+        target: foo,
+        label: 'label',
+        block: undefined
+      })
+    })
+
+    it('parses lost message', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 2, '*')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.SYNC,
+        fromOutside: false,
+        target: undefined,
+        label: '',
+        block: undefined
+      })
+    })
+
+    it('parses lost message with label', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 2, '*'),
+        new Token(TokenType.STRING, 3, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.SYNC,
+        fromOutside: false,
+        target: undefined,
+        label: 'label',
+        block: undefined
+      })
+    })
+
+    it('throws if detecting found message with no target', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, '*'),
+        new Token(TokenType.ARROW, 1, '->'),
+        new Token(TokenType.WORD, 3, '*')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('throws if missing target entirely', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.STRING, 2, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('throws if target does not exist', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 2, 'asdf')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('throws if block is specified for lost message', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 2, '*'),
+        new Token(TokenType.BLOCK_LEFT, 3, '{'),
+        new Token(TokenType.BLOCK_RIGHT, 4, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('detects type if specified', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.PAREN_LEFT, 2, '('),
+        new Token(TokenType.WORD, 3, 'async'),
+        new Token(TokenType.PAREN_RIGHT, 8, ')'),
+        new Token(TokenType.WORD, 9, 'foo')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.ASYNC,
+        fromOutside: false,
+        target: foo,
+        label: '',
+        block: undefined
+      })
+    })
+
+    it('throws if parentheses exist but no type is specified', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.PAREN_LEFT, 2, '('),
+        new Token(TokenType.PAREN_RIGHT, 3, ')'),
+        new Token(TokenType.WORD, 4, 'foo')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('throws if invalid type is specified', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.PAREN_LEFT, 2, '('),
+        new Token(TokenType.WORD, 3, 'asdf'),
+        new Token(TokenType.PAREN_RIGHT, 7, ')'),
+        new Token(TokenType.WORD, 8, 'foo')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      expect(() => parseMessageDescription(tokenAccessor, entityLookup)).to.throw(ParserError)
+    })
+
+    it('parses block contents', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 10, 'foo'),
+        new Token(TokenType.BLOCK_LEFT, 20, '{'),
+        new Token(TokenType.ARROW, 30, '->'),
+        new Token(TokenType.WORD, 40, 'bar'),
+        new Token(TokenType.WORD, 50, 'return'),
+        new Token(TokenType.STRING, 60, '"ret"'),
+        new Token(TokenType.BLOCK_RIGHT, 70, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessageDescription(tokenAccessor, entityLookup)
+      expect(parsed).to.include({
+        type: MessageType.SYNC,
+        fromOutside: false,
+        target: foo,
+        label: ''
+      })
+      expect(parsed.block).to.be.an('object')
+      const block = parsed.block as MessageBlock
+      expect(block.returnValue).to.equal('ret')
+      expect(block.activations).to.have.lengthOf(1)
+      expect(block.activations[0].message.from).to.equal(foo)
+      expect(block.activations[0].message.to).to.equal(bar)
+    })
+  })
+})

--- a/test/parser/message/parse-message.test.ts
+++ b/test/parser/message/parse-message.test.ts
@@ -1,0 +1,146 @@
+import { detectMessage, parseMessage } from '../../../src/parser/message/parse-message'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
+import { Entity, EntityType } from '../../../src/sequence/entity'
+import { EntityLookup } from '../../../src/parser/parser-state'
+import { MessageStyle } from '../../../src/sequence/message'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/parse-message.ts', function () {
+  describe('detectMessage()', function () {
+    it('returns true if given arrow', function () {
+      const token = new Token(TokenType.ARROW, 0, '->')
+      expect(detectMessage(token)).to.be.true
+    })
+
+    it('returns true if given "*"', function () {
+      const token = new Token(TokenType.WORD, 0, '*')
+      expect(detectMessage(token)).to.be.true
+    })
+
+    it('returns false if given a different word', function () {
+      const token = new Token(TokenType.WORD, 0, '**')
+      expect(detectMessage(token)).to.be.false
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.STRING, 0, '"->"')
+      expect(detectMessage(token)).to.be.false
+    })
+  })
+
+  describe('parseMessage()', function () {
+    const foo = new Entity(EntityType.COMPONENT, 'foo', 'Foo')
+    const bar = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+    const entityLookup: EntityLookup = {
+      lookupEntity (id: string): Entity | undefined {
+        return id === foo.id ? foo : (id === bar.id ? bar : undefined)
+      }
+    }
+
+    it('parses found message with label', function () {
+      const tokens = [
+        new Token(TokenType.WORD, 0, '*'),
+        new Token(TokenType.ARROW, 1, '->'),
+        new Token(TokenType.WORD, 3, 'bar'),
+        new Token(TokenType.STRING, 6, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessage(tokenAccessor, entityLookup, foo)
+      expect(parsed.message).to.include({
+        style: MessageStyle.FOUND,
+        from: undefined,
+        to: bar,
+        label: 'label'
+      })
+      expect(parsed.reply).to.be.undefined
+    })
+
+    it('parses lost message with label', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.WORD, 2, '*'),
+        new Token(TokenType.STRING, 3, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessage(tokenAccessor, entityLookup, foo)
+      expect(parsed.message).to.include({
+        style: MessageStyle.LOST,
+        from: foo,
+        to: undefined,
+        label: 'label'
+      })
+      expect(parsed.reply).to.be.undefined
+    })
+
+    it('parses regular message with type and label', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.PAREN_LEFT, 2, '('),
+        new Token(TokenType.WORD, 3, 'sync'),
+        new Token(TokenType.PAREN_RIGHT, 8, ')'),
+        new Token(TokenType.WORD, 9, 'bar'),
+        new Token(TokenType.STRING, 12, '"label"')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessage(tokenAccessor, entityLookup, foo)
+      expect(parsed.message).to.include({
+        style: MessageStyle.SYNC,
+        from: foo,
+        to: bar,
+        label: 'label'
+      })
+      expect(parsed.reply).to.include({
+        style: MessageStyle.REPLY,
+        from: bar,
+        to: foo,
+        label: ''
+      })
+    })
+
+    it('parses block contents', function () {
+      const tokens = [
+        new Token(TokenType.ARROW, 0, '->'),
+        new Token(TokenType.PAREN_LEFT, 2, '('),
+        new Token(TokenType.WORD, 3, 'sync'),
+        new Token(TokenType.PAREN_RIGHT, 8, ')'),
+        new Token(TokenType.WORD, 9, 'bar'),
+        new Token(TokenType.BLOCK_LEFT, 12, '{'),
+        new Token(TokenType.ARROW, 13, '->'),
+        new Token(TokenType.WORD, 15, 'foo'),
+        new Token(TokenType.WORD, 18, 'return'),
+        new Token(TokenType.STRING, 25, '"return value"'),
+        new Token(TokenType.BLOCK_RIGHT, 40, '}')
+      ]
+      const tokenAccessor = new TokenAccessor(new TokenStream(tokens))
+      const parsed = parseMessage(tokenAccessor, entityLookup, foo)
+      expect(parsed.message).to.include({
+        style: MessageStyle.SYNC,
+        from: foo,
+        to: bar,
+        label: ''
+      })
+      expect(parsed.reply).to.include({
+        style: MessageStyle.REPLY,
+        from: bar,
+        to: foo,
+        label: 'return value'
+      })
+      expect(parsed.children).to.have.lengthOf(1)
+      expect(parsed.children[0].message).to.include({
+        style: MessageStyle.SYNC,
+        from: bar,
+        to: foo,
+        label: ''
+      })
+      expect(parsed.children[0].reply).to.include({
+        style: MessageStyle.REPLY,
+        from: foo,
+        to: bar,
+        label: ''
+      })
+    })
+  })
+})

--- a/test/parser/message/parse-return.test.ts
+++ b/test/parser/message/parse-return.test.ts
@@ -1,0 +1,45 @@
+import { detectReturn, parseReturn } from '../../../src/parser/message/parse-return'
+import { Token, TokenType } from '../../../src/tokenizer/token'
+import { TokenStream } from '../../../src/tokenizer/token-stream'
+import { TokenAccessor } from '../../../src/parser/token-accessor'
+import { ParserError } from '../../../src/parser/errors'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/parse-return.ts', function () {
+  describe('detectReturn()', function () {
+    it('returns true if given keyword "return"', function () {
+      const token = new Token(TokenType.WORD, 0, 'return')
+      expect(detectReturn(token)).to.be.true
+    })
+
+    it('returns false if given a different keyword', function () {
+      const token = new Token(TokenType.WORD, 0, 'foo')
+      expect(detectReturn(token)).to.be.false
+    })
+
+    it('returns false if given a different token type', function () {
+      const token = new Token(TokenType.STRING, 0, '"return"')
+      expect(detectReturn(token)).to.be.false
+    })
+  })
+
+  describe('parseReturn()', function () {
+    it('parses as a string', function () {
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.WORD, 0, 'return'),
+        new Token(TokenType.STRING, 7, '"return value"')
+      ]))
+      const parsed = parseReturn(tokens)
+      expect(parsed).to.equal('return value')
+    })
+
+    it('throws if missing string token', function () {
+      const tokens = new TokenAccessor(new TokenStream([
+        new Token(TokenType.WORD, 0, 'return'),
+        new Token(TokenType.WORD, 7, 'foo')
+      ]))
+      expect(() => parseReturn(tokens)).to.throw(ParserError)
+    })
+  })
+})

--- a/test/parser/message/species/match-found-message.test.ts
+++ b/test/parser/message/species/match-found-message.test.ts
@@ -1,0 +1,124 @@
+import { matchFoundMessage } from '../../../../src/parser/message/species/match-found-message'
+import { MessageDescription, MessageType } from '../../../../src/parser/message/message-description'
+import { Entity, EntityType } from '../../../../src/sequence/entity'
+import { ParserError } from '../../../../src/parser/errors'
+import { Token, TokenType } from '../../../../src/tokenizer/token'
+import { Activation } from '../../../../src/sequence/activation'
+import { MessageStyle } from '../../../../src/sequence/message'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/species/match-found-message.ts', function () {
+  const evidenceToken = new Token(TokenType.ARROW, 0, '->')
+  const target = new Entity(EntityType.COMPONENT, 'target', 'Target')
+
+  it('returns undefined if fromOutside is false', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(matchFoundMessage(desc)).to.be.undefined
+  })
+
+  it('creates activation if everything is valid', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: true,
+      target: target,
+      label: 'label',
+      block: {
+        returnValue: undefined,
+        activations: [],
+        evidence: {
+          returnValue: evidenceToken
+        }
+      },
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    const result = matchFoundMessage(desc)
+    expect(result).to.be.an('object')
+    const activation = result as Activation
+    expect(activation.message).to.include({
+      style: MessageStyle.FOUND,
+      from: undefined,
+      to: target,
+      label: 'label'
+    })
+  })
+
+  it('throws if type is not SYNC', function () {
+    const desc: MessageDescription = {
+      type: MessageType.ASYNC,
+      fromOutside: true,
+      target: target,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchFoundMessage(desc)).to.throw(ParserError)
+  })
+
+  it('throws if target is undefined', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: true,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchFoundMessage(desc)).to.throw(ParserError)
+  })
+
+  it('throws if a return value is specified', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: true,
+      target: target,
+      label: '',
+      block: {
+        returnValue: 'return',
+        activations: [],
+        evidence: {
+          returnValue: evidenceToken
+        }
+      },
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchFoundMessage(desc)).to.throw(ParserError)
+  })
+})

--- a/test/parser/message/species/match-lost-message.test.ts
+++ b/test/parser/message/species/match-lost-message.test.ts
@@ -1,0 +1,137 @@
+import { matchLostMessage } from '../../../../src/parser/message/species/match-lost-message'
+import { MessageDescription, MessageType } from '../../../../src/parser/message/message-description'
+import { Entity, EntityType } from '../../../../src/sequence/entity'
+import { ParserError } from '../../../../src/parser/errors'
+import { Token, TokenType } from '../../../../src/tokenizer/token'
+import { Activation } from '../../../../src/sequence/activation'
+import { MessageStyle } from '../../../../src/sequence/message'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/species/match-lost-message.ts', function () {
+  const evidenceToken = new Token(TokenType.ARROW, 0, '->')
+  const target = new Entity(EntityType.COMPONENT, 'target', 'Target')
+  const active = new Entity(EntityType.COMPONENT, 'active', 'Active')
+
+  it('returns undefined if fromOutside is true', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: true,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(matchLostMessage(desc, active)).to.be.undefined
+  })
+
+  it('returns undefined if target is not undefined', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: target,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(matchLostMessage(desc, active)).to.be.undefined
+  })
+
+  it('creates activation if everything is valid', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: undefined,
+      label: 'label',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    const result = matchLostMessage(desc, active)
+    expect(result).to.be.an('object')
+    const activation = result as Activation
+    expect(activation.message).to.include({
+      style: MessageStyle.LOST,
+      from: active,
+      to: undefined,
+      label: 'label'
+    })
+  })
+
+  it('throws if type is not SYNC', function () {
+    const desc: MessageDescription = {
+      type: MessageType.ASYNC,
+      fromOutside: false,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchLostMessage(desc, active)).to.throw(ParserError)
+  })
+
+  it('throws if active is undefined', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchLostMessage(desc, undefined)).to.throw(ParserError)
+  })
+
+  it('throws if a block is specified', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: undefined,
+      label: '',
+      block: {
+        returnValue: undefined,
+        activations: [],
+        evidence: {
+          returnValue: evidenceToken
+        }
+      },
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchLostMessage(desc, active)).to.throw(ParserError)
+  })
+})

--- a/test/parser/message/species/match-regular-message.test.ts
+++ b/test/parser/message/species/match-regular-message.test.ts
@@ -1,0 +1,174 @@
+import { matchRegularMessage } from '../../../../src/parser/message/species/match-regular-message'
+import { MessageDescription, MessageType } from '../../../../src/parser/message/message-description'
+import { Entity, EntityType } from '../../../../src/sequence/entity'
+import { ParserError } from '../../../../src/parser/errors'
+import { Token, TokenType } from '../../../../src/tokenizer/token'
+import { Activation } from '../../../../src/sequence/activation'
+import { MessageStyle, SyncMessage } from '../../../../src/sequence/message'
+
+import { expect } from 'chai'
+
+describe('src/parser/message/species/match-regular-message.ts', function () {
+  const evidenceToken = new Token(TokenType.ARROW, 0, '->')
+  const target = new Entity(EntityType.COMPONENT, 'target', 'Target')
+  const active = new Entity(EntityType.COMPONENT, 'active', 'Active')
+
+  it('returns undefined if fromOutside is true', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: true,
+      target: target,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(matchRegularMessage(desc, active)).to.be.undefined
+  })
+
+  it('returns undefined if target is undefined', function () {
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: undefined,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(matchRegularMessage(desc, active)).to.be.undefined
+  })
+
+  it('creates activation if everything is valid (no block)', function () {
+    const check = (type: MessageType, expectedStyle: MessageStyle): void => {
+      const desc: MessageDescription = {
+        type: type,
+        fromOutside: false,
+        target: target,
+        label: 'label',
+        block: undefined,
+        evidence: {
+          type: evidenceToken,
+          fromOutside: evidenceToken,
+          target: evidenceToken,
+          label: evidenceToken,
+          block: evidenceToken
+        }
+      }
+      const result = matchRegularMessage(desc, active)
+      expect(result).to.be.an('object')
+      const activation = result as Activation
+      expect(activation.message).to.include({
+        style: expectedStyle,
+        from: active,
+        to: target,
+        label: 'label'
+      })
+    }
+    check(MessageType.SYNC, MessageStyle.SYNC)
+    check(MessageType.ASYNC, MessageStyle.ASYNC)
+    check(MessageType.CREATE, MessageStyle.CREATE)
+    check(MessageType.DESTROY, MessageStyle.DESTROY)
+  })
+
+  it('includes block for SYNC and ASYNC', function () {
+    const check = (type: MessageType, expectedStyle: MessageStyle): void => {
+      const child = new Activation(new SyncMessage(target, active, 'child'), undefined, [])
+      const desc: MessageDescription = {
+        type: type,
+        fromOutside: false,
+        target: target,
+        label: 'label',
+        block: {
+          returnValue: 'return value',
+          activations: [child],
+          evidence: {
+            returnValue: evidenceToken
+          }
+        },
+        evidence: {
+          type: evidenceToken,
+          fromOutside: evidenceToken,
+          target: evidenceToken,
+          label: evidenceToken,
+          block: evidenceToken
+        }
+      }
+      const result = matchRegularMessage(desc, active)
+      expect(result).to.be.an('object')
+      const activation = result as Activation
+      expect(activation.message).to.include({
+        style: expectedStyle,
+        from: active,
+        to: target,
+        label: 'label'
+      })
+      expect(activation.reply).to.include({
+        style: MessageStyle.REPLY,
+        from: target,
+        to: active,
+        label: 'return value'
+      })
+      expect(activation.children).to.deep.equal([child])
+    }
+    check(MessageType.SYNC, MessageStyle.SYNC)
+    check(MessageType.ASYNC, MessageStyle.ASYNC)
+  })
+
+  it('throws if block exists for CREATE or DESTROY', function () {
+    const check = (type: MessageType): void => {
+      const desc: MessageDescription = {
+        type: type,
+        fromOutside: false,
+        target: target,
+        label: 'label',
+        block: {
+          returnValue: undefined,
+          activations: [],
+          evidence: {
+            returnValue: evidenceToken
+          }
+        },
+        evidence: {
+          type: evidenceToken,
+          fromOutside: evidenceToken,
+          target: evidenceToken,
+          label: evidenceToken,
+          block: evidenceToken
+        }
+      }
+      expect(() => matchRegularMessage(desc, active)).to.throw()
+    }
+    check(MessageType.CREATE)
+    check(MessageType.DESTROY)
+  })
+
+  it('throws if active is undefined', function () {
+    const evidenceToken = new Token(TokenType.ARROW, 0, '->')
+    const desc: MessageDescription = {
+      type: MessageType.SYNC,
+      fromOutside: false,
+      target: target,
+      label: '',
+      block: undefined,
+      evidence: {
+        type: evidenceToken,
+        fromOutside: evidenceToken,
+        target: evidenceToken,
+        label: evidenceToken,
+        block: evidenceToken
+      }
+    }
+    expect(() => matchRegularMessage(desc, undefined)).to.throw(ParserError)
+  })
+})

--- a/test/parser/parser.test.ts
+++ b/test/parser/parser.test.ts
@@ -25,8 +25,28 @@ describe('src/parser/parser.ts', function () {
     ])
     const parsed = parse(tokens)
     expect(parsed.entities).to.have.lengthOf(2)
+    expect(parsed.entities[0]).to.include({ id: 'foo', name: 'Foo' })
+    expect(parsed.entities[1]).to.include({ id: 'bar', name: 'Bar' })
+  })
+
+  it('parses found messages', function () {
+    const tokens = new TokenStream([
+      new Token(TokenType.WORD, 0, 'object'),
+      new Token(TokenType.WORD, 7, 'foo'),
+      new Token(TokenType.EQUALS, 10, '='),
+      new Token(TokenType.STRING, 11, '"Foo"'),
+      new Token(TokenType.WORD, 18, '*'),
+      new Token(TokenType.ARROW, 19, '->'),
+      new Token(TokenType.WORD, 21, 'foo'),
+      new Token(TokenType.STRING, 25, '"message"')
+    ])
+    const parsed = parse(tokens)
+    expect(parsed.entities).to.have.lengthOf(1)
     expect(parsed.entities[0].id).to.equal('foo')
-    expect(parsed.entities[1].id).to.equal('bar')
+    expect(parsed.activations).to.have.lengthOf(1)
+    expect(parsed.activations[0].message.from).to.be.undefined
+    expect(parsed.activations[0].message.to).to.equal(parsed.entities[0])
+    expect(parsed.activations[0].message.label).to.equal('message')
   })
 
   it('throws for unexpected token (global level)', function () {


### PR DESCRIPTION
This PR implements parsing messages.
Synchronous, asynchronous, `create` and `destroy` messages as well as lost messages and found messages are supported.
Messages can have labels and they can have nested child messages.
Reply messages can be specified via `return` statements that take any string.

For more detail on the syntax, refer to the updated README.md.