### PR TITLE
Add renderer interface, implement SVG renderer

### DIFF
--- a/src/renderer/browser-svg/browser-svg-renderer.ts
+++ b/src/renderer/browser-svg/browser-svg-renderer.ts
@@ -1,0 +1,165 @@
+import { DirectRenderer, StrokeOptions } from '../renderer'
+import { Size } from '../../util/geometry/size'
+import { Point } from '../../util/geometry/point'
+
+type AttributeValue = string | number | undefined
+
+function createSvgElement (tagName: string): SVGElement {
+  return document.createElementNS('http://www.w3.org/2000/svg', tagName)
+}
+
+function applyAttributes (element: SVGElement, attrs: Record<string, AttributeValue>): void {
+  for (const key of Object.keys(attrs)) {
+    const value = attrs[key]
+    if (value == null) continue
+    element.setAttribute(key, String(value))
+  }
+}
+
+function measureText (text: string, fontSize: number): Size {
+  const element = createSvgElement('text') as SVGTextElement
+  applyAttributes(element, {
+    'font-size': fontSize
+  })
+  element.appendChild(document.createTextNode(text))
+
+  const measureSvg = createSvgElement('svg')
+  measureSvg.appendChild(element)
+
+  document.body.appendChild(measureSvg)
+  const box = element.getBBox()
+  document.body.removeChild(measureSvg)
+
+  return new Size(box.width, box.height)
+}
+
+function getViewBox (size: Size, hPadding: number, vPadding: number): string {
+  const minX = -hPadding
+  const minY = -vPadding
+  const width = size.width + 2 * hPadding
+  const height = size.height + 2 * vPadding
+
+  return `${minX} ${minY} ${width} ${height}`
+}
+
+function convertStrokeToAttributes (options?: StrokeOptions): Record<string, AttributeValue> {
+  return {
+    'stroke-width': options?.lineWidth ?? 1,
+    'stroke-dasharray': (options?.dashed ?? false) ? '4' : ''
+  }
+}
+
+/**
+ * A renderer implementation that renders to an SVG directly in the browser.
+ * For this to work, the code needs to run in an actual browser with access to a DOM.
+ * The renderer may need to temporarily append nodes to the body (e.g. for measuring).
+ */
+export class BrowserSvgRenderer implements DirectRenderer<SVGSVGElement> {
+  private readonly hPadding: number
+  private readonly vPadding: number
+  private foregroundColor: string = '#000'
+  private backgroundColor: string = '#FFF'
+
+  private svg: SVGSVGElement | undefined
+
+  constructor (hPadding: number, vPadding: number) {
+    if (window == null || window.document == null) {
+      throw new Error('cannot use this renderer outside the browser')
+    }
+
+    this.hPadding = hPadding
+    this.vPadding = vPadding
+  }
+
+  private addToRender (element: SVGElement): void {
+    if (this.svg == null) {
+      throw new Error('renderer not prepared')
+    }
+    this.svg.appendChild(element)
+  }
+
+  /**
+   * Configure colors that are different from the defaults (black foreground, white background).
+   * Any CSS color value can be used.
+   * The background is used for rendering boxes, and the foreground for strokes and texts.
+   *
+   * @param {string} foreground The foreground color.
+   * @param {string} background The background color.
+   * @returns {void}
+   */
+  setColors (foreground: string, background: string): void {
+    this.foregroundColor = foreground
+    this.backgroundColor = background
+  }
+
+  prepare (canvasSize: Size): void {
+    this.svg = createSvgElement('svg') as SVGSVGElement
+    applyAttributes(this.svg, {
+      viewBox: getViewBox(canvasSize, this.hPadding, this.vPadding),
+      width: canvasSize.width + 2 * this.hPadding,
+      height: canvasSize.height + 2 * this.vPadding
+    })
+  }
+
+  finish (): SVGSVGElement {
+    if (this.svg == null) {
+      throw new Error('renderer not prepared')
+    }
+    return this.svg
+  }
+
+  measureText (str: string, fontSize: number): Size {
+    return measureText(str, fontSize)
+  }
+
+  renderBox (start: Point, size: Size, options?: StrokeOptions): void {
+    const element = createSvgElement('rect')
+    applyAttributes(element, {
+      x: start.x,
+      y: start.y,
+      width: size.width,
+      height: size.height,
+      fill: this.backgroundColor,
+      stroke: this.foregroundColor,
+      ...convertStrokeToAttributes(options)
+    })
+    this.addToRender(element)
+  }
+
+  renderLine (start: Point, end: Point, options?: StrokeOptions): void {
+    const element = createSvgElement('line')
+    applyAttributes(element, {
+      x1: start.x,
+      y1: start.y,
+      x2: end.x,
+      y2: end.y,
+      stroke: this.foregroundColor,
+      ...convertStrokeToAttributes(options)
+    })
+    this.addToRender(element)
+  }
+
+  renderPath (data: string, offset: Point, options?: StrokeOptions): void {
+    const element = createSvgElement('path')
+    applyAttributes(element, {
+      d: data,
+      transform: `translate(${offset.x} ${offset.y})`,
+      fill: 'none',
+      stroke: this.foregroundColor,
+      ...convertStrokeToAttributes(options)
+    })
+    this.addToRender(element)
+  }
+
+  renderText (text: string, position: Point, fontSize: number): void {
+    const element = createSvgElement('text')
+    applyAttributes(element, {
+      x: position.x,
+      y: position.y,
+      'font-size': fontSize,
+      fill: this.foregroundColor
+    })
+    element.appendChild(document.createTextNode(text))
+    this.addToRender(element)
+  }
+}

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,0 +1,99 @@
+import { Size } from '../util/geometry/size'
+import { Point } from '../util/geometry/point'
+
+/**
+ * This interface defines how stroke should be applied to a shape when rendering.
+ */
+export interface StrokeOptions {
+  lineWidth?: number
+  dashed?: boolean
+}
+
+/**
+ * This interface can be used to perform measurements related to rendering.
+ * This is useful, for example, when laying out elements soon to be drawn.
+ */
+export interface RenderAttributes {
+  /**
+   * Measure the size of a piece of text, if it were to be rendered using this configuration.
+   *
+   * @param {string} str The text to be measured.
+   * @param {number} fontSize The font size (in pixels) to use.
+   * @returns {Size} The measured size.
+   */
+  measureText: (str: string, fontSize: number) => Size
+}
+
+/**
+ * The renderer interface enables drawing shapes to an abstract canvas.
+ */
+export interface Renderer extends RenderAttributes {
+  /**
+   * Render a rectangular box, starting at the given coordinates and extending for a given size.
+   *
+   * @param {Point} start The upper-left corner location.
+   * @param {Size} size The box size.
+   * @param {?object} options Options for stroking the box. If not provided, sensible defaults will be used.
+   * @returns {void}
+   */
+  renderBox: (start: Point, size: Size, options?: StrokeOptions) => void
+
+  /**
+   * Render a simple line from one point to another.
+   *
+   * @param {Point} start The first point.
+   * @param {Point} end The second point.
+   * @param {?object} options Options for stroking the line. If not provided, sensible defaults will be used.
+   * @returns {void}
+   */
+  renderLine: (start: Point, end: Point, options?: StrokeOptions) => void
+
+  /**
+   * Render a path (SVG path data format).
+   * The path coordinates are shifted by the given offset (offset added to path coordinates).
+   *
+   * @param {string} data The path data.
+   * @param {Point} offset The location of the origin of this path.
+   * @param {?object} options Options for stroking the path. If not provided, sensible defaults will be used.
+   * @returns {void}
+   */
+  renderPath: (data: string, offset: Point, options?: StrokeOptions) => void
+
+  /**
+   * Render a text at the given position.
+   *
+   * @param {string} text The text to render.
+   * @param {Point} offset The starting coordinate (beginning of line, baseline height).
+   * @param {number} fontSize The font size (in pixels) to use for rendering.
+   * @returns {void}
+   */
+  renderText: (text: string, position: Point, fontSize: number) => void
+}
+
+/**
+ * A "direct renderer" is a renderer that draws directly to some target object,
+ * and when finished, provides the rendering result to the caller.
+ *
+ * The renderer needs to be prepared (call prepare()) before any rendering calls can be made.
+ * At this point, the target size needs to be known, but this is not an issue because measurement methods
+ * can always be called, even before preparation.
+ *
+ * When no more rendering needs to be done, call finish() to produce the result.
+ */
+export interface DirectRenderer<OutputType> extends Renderer {
+  /**
+   * Set up this renderer for a drawing of the given size.
+   * This needs to be called before any rendering can happen.
+   *
+   * @param {Size} canvasSize The coordinate range in which rendering will occur.
+   * @returns {void}
+   */
+  prepare: (canvasSize: Size) => void
+
+  /**
+   * Finish rendering and produce the result.
+   *
+   * @returns {object} The rendered result.
+   */
+  finish: () => OutputType
+}

--- a/src/util/geometry/point.ts
+++ b/src/util/geometry/point.ts
@@ -1,0 +1,45 @@
+export class Point {
+  /**
+   * The point (0, 0).
+   */
+  static readonly ORIGIN: Point = new Point(0, 0)
+
+  readonly x: number
+  readonly y: number
+
+  constructor (x: number, y: number) {
+    this.x = x
+    this.y = y
+  }
+
+  /**
+   * Create a new point whose coordinates are the sum of this one's and the given deltas.
+   *
+   * @param {number} dx The amount to add on the x-axis.
+   * @param {number} dy The amount to add on the y-axis.
+   * @returns {Point} A new Point object with the shifted coordinates.
+   */
+  translate (dx: number, dy: number): Point {
+    return new Point(this.x + dx, this.y + dy)
+  }
+
+  /**
+   * Create a copy of this point where the Y coordinate is the same, but the X coordinate is set to the one given.
+   *
+   * @param {number} x The new x coordinate.
+   * @returns {Point} A new Point with the coordinates set as described above.
+   */
+  withX (x: number): Point {
+    return new Point(x, this.y)
+  }
+
+  /**
+   * Create a copy of this point where the X coordinate is the same, but the Y coordinate is set to the one given.
+   *
+   * @param {number} y The new y coordinate.
+   * @returns {Point} A new Point with the coordinates set as described above.
+   */
+  withY (y: number): Point {
+    return new Point(this.x, y)
+  }
+}

--- a/src/util/geometry/size.ts
+++ b/src/util/geometry/size.ts
@@ -1,0 +1,28 @@
+/**
+ * A 2D size.
+ */
+export class Size {
+  /**
+   * Zero width, zero height.
+   */
+  static readonly ZERO: Size = new Size(0, 0)
+
+  readonly width: number
+  readonly height: number
+
+  constructor (width: number, height: number) {
+    this.width = Math.max(0, width)
+    this.height = Math.max(0, height)
+  }
+
+  /**
+   * Create a new object that is the sum of this one and the given deltas.
+   *
+   * @param {number} dWidth The amount by which to grow this size width-wise.
+   * @param {number} dHeight The amount by which to grow this size height-wise.
+   * @returns {Size} A new Size object with the combined dimensions.
+   */
+  add (dWidth: number, dHeight: number): Size {
+    return new Size(this.width + dWidth, this.height + dHeight)
+  }
+}

--- a/test/util/geometry/point.test.ts
+++ b/test/util/geometry/point.test.ts
@@ -1,0 +1,76 @@
+import { Point } from '../../../src/util/geometry/point'
+
+import { expect } from 'chai'
+
+describe('src/util/geometry/point.ts', function () {
+  describe('ORIGIN', function () {
+    it('is the point (0,0)', function () {
+      expect(Point.ORIGIN).to.be.an.instanceOf(Point)
+      expect(Point.ORIGIN.x).to.equal(0)
+      expect(Point.ORIGIN.y).to.equal(0)
+    })
+  })
+
+  describe('constructor', function () {
+    it('stores x, y values as given', function () {
+      expect(new Point(42.25, 37.75).x).to.equal(42.25)
+      expect(new Point(42.25, 37.75).y).to.equal(37.75)
+      expect(new Point(-42.25, 37.75).x).to.equal(-42.25)
+      expect(new Point(42.25, -37.75).y).to.equal(-37.75)
+    })
+  })
+
+  describe('#translate()', function () {
+    it('adds the given deltas to the coordinates', function () {
+      expect(new Point(10, -15).translate(12.25, 17.75).x).to.equal(22.25)
+      expect(new Point(10, -15).translate(12.25, 17.75).y).to.equal(2.75)
+      expect(new Point(10, 15).translate(-12.25, -17.75).x).to.equal(-2.25)
+      expect(new Point(10, 15).translate(-12.25, -17.75).y).to.equal(-2.75)
+    })
+
+    it('does not modify the original point', function () {
+      const obj = new Point(42, 37)
+      obj.translate(3, 3)
+      expect(obj.x).to.equal(42)
+      expect(obj.y).to.equal(37)
+    })
+  })
+
+  describe('#withX()', function () {
+    it('sets the x coordinate', function () {
+      expect(new Point(10, -15).withX(42).x).to.equal(42)
+      expect(new Point(10, -15).withX(-42).x).to.equal(-42)
+    })
+
+    it('keeps the y coordinate', function () {
+      expect(new Point(10, -15).withX(42).y).to.equal(-15)
+      expect(new Point(10, -15).withX(-42).y).to.equal(-15)
+    })
+
+    it('does not modify the original point', function () {
+      const obj = new Point(42, 37)
+      obj.withX(3)
+      expect(obj.x).to.equal(42)
+      expect(obj.y).to.equal(37)
+    })
+  })
+
+  describe('#withY()', function () {
+    it('sets the y coordinate', function () {
+      expect(new Point(10, -15).withY(42).y).to.equal(42)
+      expect(new Point(10, -15).withY(-42).y).to.equal(-42)
+    })
+
+    it('keeps the x coordinate', function () {
+      expect(new Point(10, -15).withY(42).x).to.equal(10)
+      expect(new Point(10, -15).withY(-42).x).to.equal(10)
+    })
+
+    it('does not modify the original point', function () {
+      const obj = new Point(42, 37)
+      obj.withY(3)
+      expect(obj.x).to.equal(42)
+      expect(obj.y).to.equal(37)
+    })
+  })
+})

--- a/test/util/geometry/size.test.ts
+++ b/test/util/geometry/size.test.ts
@@ -1,0 +1,52 @@
+import { Size } from '../../../src/util/geometry/size'
+
+import { expect } from 'chai'
+
+describe('src/util/geometry/size.ts', function () {
+  describe('ZERO', function () {
+    it('is a Size with zero width and zero height', function () {
+      expect(Size.ZERO).to.be.an.instanceOf(Size)
+      expect(Size.ZERO.width).to.equal(0)
+      expect(Size.ZERO.height).to.equal(0)
+    })
+  })
+
+  describe('constructor', function () {
+    it('stores width, height values', function () {
+      expect(new Size(42.25, 37.75).width).to.equal(42.25)
+      expect(new Size(42.25, 37.75).height).to.equal(37.75)
+      expect(new Size(0, 0).width).to.equal(0)
+      expect(new Size(0, 0).height).to.equal(0)
+    })
+
+    it('sets negative values to 0', function () {
+      expect(new Size(0, 37.75).width).to.equal(0)
+      expect(new Size(0, 37.75).height).to.equal(37.75)
+      expect(new Size(42.25, 0).width).to.equal(42.25)
+      expect(new Size(42.25, 0).height).to.equal(0)
+    })
+  })
+
+  describe('#add()', function () {
+    it('adds the given deltas to the dimensions', function () {
+      expect(new Size(10, 0).add(3, 7.75).width).to.equal(13)
+      expect(new Size(10, 0).add(3, 7.75).height).to.equal(7.75)
+      expect(new Size(10, 15).add(-3, -7.75).width).to.equal(7)
+      expect(new Size(10, 15).add(-3, -7.75).height).to.equal(7.25)
+    })
+
+    it('sets negative result values to 0', function () {
+      expect(new Size(10, 0).add(-12.25, 7.75).width).to.equal(0)
+      expect(new Size(10, 0).add(-12.25, 7.75).height).to.equal(7.75)
+      expect(new Size(10, 15).add(-2.25, -17.75).width).to.equal(7.75)
+      expect(new Size(10, 15).add(-2.25, -17.75).height).to.equal(0)
+    })
+
+    it('does not modify the original size', function () {
+      const obj = new Size(42, 37)
+      obj.add(3, 3)
+      expect(obj.width).to.equal(42)
+      expect(obj.height).to.equal(37)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds interface definitions for generic renderers to any type of output.
It also adds an implementation of that interface for output as a dynamically-generated SVG inside of Web browsers.