### PR TITLE
feat(diagram): Implement Drawable classes for entity diagram parts

### DIFF
--- a/src/diagram/config.ts
+++ b/src/diagram/config.ts
@@ -1,0 +1,5 @@
+export const COMPONENT_HEAD_PADDING_H = 8
+export const COMPONENT_HEAD_PADDING_V = 12
+
+export const FONT_SIZE = 16
+export const LINE_WIDTH_LIFELINES = 1

--- a/src/diagram/drawables/actor-head-drawable.ts
+++ b/src/diagram/drawables/actor-head-drawable.ts
@@ -1,0 +1,48 @@
+import { HeadDrawable } from './head-drawable'
+import { TextAlignment, TextDrawable } from './text-drawable'
+import { StickFigureDrawable } from './stick-figure-drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+
+/**
+ * An entity head Drawable for entities of type "Actor".
+ * They are drawn as a stick figure, with their name beneath the pictogram.
+ */
+export class ActorHeadDrawable implements HeadDrawable {
+  private readonly text: TextDrawable
+  private readonly figure: StickFigureDrawable
+
+  private readonly vSpacing: number = 4
+
+  private topCenter: Point = Point.ORIGIN
+
+  constructor (name: string) {
+    this.text = new TextDrawable(name)
+    this.figure = new StickFigureDrawable()
+  }
+
+  setTopCenter (topCenter: Point): void {
+    this.topCenter = topCenter
+  }
+
+  measure (attr: RenderAttributes): Size {
+    const textSize = this.text.measure(attr)
+    const figureSize = this.figure.measure(attr)
+
+    const width = Math.max(textSize.width, figureSize.width)
+    const height = textSize.height + this.vSpacing + figureSize.height
+
+    return new Size(width, height)
+  }
+
+  draw (renderer: Renderer): void {
+    const figureSize = this.figure.measure(renderer)
+
+    this.figure.setTopCenter(this.topCenter)
+    this.text.setPosition(this.topCenter.translate(0, figureSize.height), TextAlignment.CENTER_BELOW)
+
+    this.figure.draw(renderer)
+    this.text.draw(renderer)
+  }
+}

--- a/src/diagram/drawables/box-drawable.ts
+++ b/src/diagram/drawables/box-drawable.ts
@@ -1,0 +1,47 @@
+import { Drawable } from './drawable'
+import { Size } from '../../util/geometry/size'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+
+/**
+ * A Drawable that draws a rectangular box with a strong outline.
+ */
+export class BoxDrawable implements Drawable {
+  private size: Size = Size.ZERO
+  private start: Point = Point.ORIGIN
+
+  constructor (size?: Size, start?: Point) {
+    if (size != null) this.size = size
+    if (start != null) this.start = start
+  }
+
+  /**
+   * Set the size of the rectangle.
+   * This needs to be called before measurement.
+   *
+   * @param {Size} size The size.
+   */
+  setSize (size: Size): void {
+    this.size = size
+  }
+
+  /**
+   * Set the position of this rectangle via the top-left corner.
+   * The box expands downwards and to the right from this location.
+   *
+   * @param {Point} start The position.
+   */
+  setTopLeft (start: Point): void {
+    this.start = start
+  }
+
+  measure (_attr: RenderAttributes): Size {
+    return this.size
+  }
+
+  draw (renderer: Renderer): void {
+    renderer.renderBox(this.start, this.size, {
+      lineWidth: 2
+    })
+  }
+}

--- a/src/diagram/drawables/component-head-drawable.ts
+++ b/src/diagram/drawables/component-head-drawable.ts
@@ -1,0 +1,44 @@
+import { HeadDrawable } from './head-drawable'
+import { TextAlignment, TextDrawable } from './text-drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+import { BoxDrawable } from './box-drawable'
+import { COMPONENT_HEAD_PADDING_H, COMPONENT_HEAD_PADDING_V } from '../config'
+
+/**
+ * An entity head Drawable for entities of type "Component".
+ * They are drawn as a box surrounding the entity's name.
+ */
+export class ComponentHeadDrawable implements HeadDrawable {
+  private readonly text: TextDrawable
+  private readonly box: BoxDrawable
+
+  private topCenter: Point = Point.ORIGIN
+
+  constructor (name: string) {
+    this.text = new TextDrawable(name)
+    this.box = new BoxDrawable()
+  }
+
+  setTopCenter (topCenter: Point): void {
+    this.topCenter = topCenter
+  }
+
+  measure (attr: RenderAttributes): Size {
+    return this.text.measure(attr).add(2 * COMPONENT_HEAD_PADDING_H, 2 * COMPONENT_HEAD_PADDING_V)
+  }
+
+  draw (renderer: Renderer): void {
+    const size = this.measure(renderer)
+
+    this.box.setTopLeft(this.topCenter.translate(-size.width / 2, 0))
+    this.box.setSize(size)
+
+    const boxCenter = this.topCenter.translate(0, size.height / 2)
+    this.text.setPosition(boxCenter, TextAlignment.CENTER_CENTER)
+
+    this.box.draw(renderer)
+    this.text.draw(renderer)
+  }
+}

--- a/src/diagram/drawables/drawable.ts
+++ b/src/diagram/drawables/drawable.ts
@@ -1,0 +1,25 @@
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+
+/**
+ * A Drawable is something that can be measured (has an intrinsic Size)
+ * and can be drawn to a renderer.
+ */
+export interface Drawable {
+  /**
+   * Determine the size of this Drawable, using the given rendering attributes.
+   *
+   * This is not a stateful operation (i.e., no layout is computed).
+   * In other words, it is not necessary to call this before calling #draw().
+   *
+   * @param {object} attr The rendering attributes used to determine e.g. the sizes of strings.
+   */
+  measure: (attr: RenderAttributes) => Size
+
+  /**
+   * Draw this Drawable to the given renderer.
+   *
+   * @param {object} renderer The renderer.
+   */
+  draw: (renderer: Renderer) => void
+}

--- a/src/diagram/drawables/head-drawable.ts
+++ b/src/diagram/drawables/head-drawable.ts
@@ -1,0 +1,20 @@
+import { Drawable } from './drawable'
+import { Point } from '../../util/geometry/point'
+
+/**
+ * An extension to the drawable interface for methods specific to entity heads
+ * (the boxes/pictograms and names sitting atop the actual line part of a lifeline).
+ */
+export interface HeadDrawable extends Drawable {
+  /**
+   * Set the position of this head.
+   *
+   * The given point (x, y) determines the height y at which the head starts, expanding downwards,
+   * and the horizontal center x (i.e., the x coordinate of the lifeline line).
+   *
+   * This does not affect measurement but it does affect drawing.
+   *
+   * @param {Point} topCenter The position of this head.
+   */
+  setTopCenter: (topCenter: Point) => void
+}

--- a/src/diagram/drawables/lifeline-drawable.ts
+++ b/src/diagram/drawables/lifeline-drawable.ts
@@ -1,0 +1,75 @@
+import { Drawable } from './drawable'
+import { HeadDrawable } from './head-drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+import { LINE_WIDTH_LIFELINES } from '../config'
+
+/**
+ * A drawable for a complete entity lifeline, including a configurable head and the line itself.
+ */
+export class LifelineDrawable implements Drawable {
+  private readonly head: HeadDrawable
+
+  private position: Point = Point.ORIGIN
+  private endHeight: number = 0
+
+  constructor (head: HeadDrawable) {
+    this.head = head
+  }
+
+  /**
+   * Set the position of this lifeline.
+   *
+   * The y coordinate determines the height below which the head (and, later, the lifeline line) appear.
+   * The x coordinate determines the center location of the lifeline.
+   *
+   * @param {Point} position The position.
+   */
+  setTopCenter (position: Point): void {
+    this.position = position
+  }
+
+  /**
+   * Set the y coordinate at which the lifeline stops. This is an absolute coordinate,
+   * independent of the lifeline's anchor position.
+   *
+   * @param {number} endHeight The absolute height at which the lifeline stops.
+   */
+  setEndHeight (endHeight: number): void {
+    this.endHeight = endHeight
+  }
+
+  /**
+   * Measure just the head portion of this lifeline.
+   * This is useful for laying out the lifeline, because #measure() would include the line length.
+   *
+   * @param {object} attr The rendering attributes.
+   */
+  measureHead (attr: RenderAttributes): Size {
+    return this.head.measure(attr)
+  }
+
+  measure (attr: RenderAttributes): Size {
+    const headSize = this.head.measure(attr)
+
+    const width = headSize.width
+    const height = Math.max(headSize.height, this.endHeight - this.position.y)
+
+    return new Size(width, height)
+  }
+
+  draw (renderer: Renderer): void {
+    const headSize = this.head.measure(renderer)
+
+    this.head.setTopCenter(this.position)
+    this.head.draw(renderer)
+
+    const lineStart = this.position.translate(0, headSize.height)
+    const lineEnd = this.position.withY(this.endHeight)
+    renderer.renderLine(lineStart, lineEnd, {
+      lineWidth: LINE_WIDTH_LIFELINES,
+      dashed: true
+    })
+  }
+}

--- a/src/diagram/drawables/stick-figure-drawable.ts
+++ b/src/diagram/drawables/stick-figure-drawable.ts
@@ -1,0 +1,34 @@
+import { Drawable } from './drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+
+const STICK_FIGURE_PATH = 'M0,0 a8,8,0,1,0,0,16  M0,0 a8,8,0,1,1,0,16  M0,16 v20  M-15,22 h30  M-10,46 l10,-10 l10,10'
+
+/**
+ * A stick figure pictogram as a Drawable.
+ */
+export class StickFigureDrawable implements Drawable {
+  private topCenter: Point = Point.ORIGIN
+
+  /**
+   * Sets the position of this pictogram.
+   * The position specifies the y-height for the top edge of the pictogram
+   * and the x position for the center of the pictogram.
+   *
+   * @param {Point} topCenter The position.
+   */
+  setTopCenter (topCenter: Point): void {
+    this.topCenter = topCenter
+  }
+
+  measure (_attr: RenderAttributes): Size {
+    return new Size(30, 46)
+  }
+
+  draw (renderer: Renderer): void {
+    renderer.renderPath(STICK_FIGURE_PATH, this.topCenter, {
+      lineWidth: 2
+    })
+  }
+}

--- a/src/diagram/drawables/text-drawable.ts
+++ b/src/diagram/drawables/text-drawable.ts
@@ -1,0 +1,74 @@
+import { Drawable } from './drawable'
+import { Point } from '../../util/geometry/point'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+import { FONT_SIZE } from '../config'
+
+/**
+ * Enum specifying how to align text around the set position.
+ *
+ * For example, the text could be fully centered around that point,
+ * or only centered on the x-axis but with the baseline located at the point's y coordinate, etc.
+ */
+export enum TextAlignment {
+  CENTER_CENTER,
+  CENTER_ABOVE,
+  CENTER_BELOW
+}
+
+interface Offset {
+  x: number
+  y: number
+}
+
+function getOffsetForAlignment (align: TextAlignment, textSize: Size): Offset {
+  switch (align) {
+    case TextAlignment.CENTER_ABOVE:
+      return { x: -textSize.width / 2, y: 0 }
+    case TextAlignment.CENTER_CENTER:
+      return { x: -textSize.width / 2, y: textSize.height / 2 }
+    case TextAlignment.CENTER_BELOW:
+      return { x: -textSize.width / 2, y: textSize.height }
+  }
+}
+
+/**
+ * A drawable for a piece of text.
+ * This includes special alignment logic, so using this is preferred over rendering text manually.
+ */
+export class TextDrawable implements Drawable {
+  private readonly text: string
+  private readonly fontSize: number
+  private position: Point = Point.ORIGIN
+  private align: TextAlignment = TextAlignment.CENTER_CENTER
+
+  constructor (text: string, fontSize: number = FONT_SIZE) {
+    this.text = text
+    this.fontSize = fontSize
+  }
+
+  /**
+   * Set the position of this text.
+   *
+   * The text is positioned relative to the given point, with its offset determined by the given alignment.
+   * The alignment might have the text centered around the given point,
+   * aligned flush to one of its edges, etc.
+   *
+   * @param {Point} pos The position.
+   * @param {TextAlignment} align The alignment specifier.
+   */
+  setPosition (pos: Point, align: TextAlignment): void {
+    this.position = pos
+    this.align = align
+  }
+
+  measure (attr: RenderAttributes): Size {
+    return attr.measureText(this.text, this.fontSize)
+  }
+
+  draw (renderer: Renderer): void {
+    const offset = getOffsetForAlignment(this.align, this.measure(renderer))
+    const pos = this.position.translate(offset.x, offset.y)
+    renderer.renderText(this.text, pos, this.fontSize)
+  }
+}

--- a/test/diagram/drawables/actor-head-drawable.test.ts
+++ b/test/diagram/drawables/actor-head-drawable.test.ts
@@ -1,0 +1,68 @@
+import { ActorHeadDrawable } from '../../../src/diagram/drawables/actor-head-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/actor-head-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns size depending on name text size', function () {
+      // This is an extremely imprecise test. I did not have the patience to make this more thorough.
+      function check (textSize: Size, minWidth: number, maxWidth: number, minHeight: number): void {
+        const attr: RenderAttributes = {
+          measureText: (text: string) => {
+            expect(text).to.equal(' foo bar ')
+            return textSize
+          }
+        }
+        const result = new ActorHeadDrawable(' foo bar ').measure(attr)
+        expect(result.width).to.be.within(minWidth, maxWidth)
+        expect(result.height).to.be.greaterThan(minHeight)
+      }
+      check(new Size(5, 5), 5, 100, 10)
+      check(new Size(500, 500), 500, 600, 505)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('calls renderPath followed by renderText with name', function (done) {
+      let pathCalled = false
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPath: () => {
+          expect(pathCalled).to.be.false
+          pathCalled = true
+        },
+        renderText: (text: string) => {
+          expect(pathCalled).to.be.true
+          expect(text).to.equal(' foo bar ')
+          done()
+        },
+        measureText: () => new Size(40, 15)
+      }
+      const obj = new ActorHeadDrawable(' foo bar ')
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position', function () {
+      const position = new Point(50, 100)
+
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPath: (data, pos) => {
+          expect(pos).to.deep.equal(position)
+        },
+        renderText: (text: string, pos) => {
+          expect(pos.y).to.be.greaterThan(position.y)
+        },
+        measureText: () => Size.ZERO
+      }
+      const obj = new ActorHeadDrawable('')
+      obj.setTopCenter(position)
+      obj.draw(renderer)
+    })
+  })
+})

--- a/test/diagram/drawables/box-drawable.test.ts
+++ b/test/diagram/drawables/box-drawable.test.ts
@@ -1,0 +1,66 @@
+import { BoxDrawable } from '../../../src/diagram/drawables/box-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/box-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns size set in constructor', function () {
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      expect(new BoxDrawable().measure(attr)).to.include({
+        width: 0,
+        height: 0
+      })
+      const size = new Size(42.25, 37.75)
+      expect(new BoxDrawable(size).measure(attr)).to.deep.equal(size)
+    })
+
+    it('allows overriding size via #setSize()', function () {
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      const size = new Size(42.25, 37.75)
+      const obj = new BoxDrawable()
+      obj.setSize(size)
+      expect(obj.measure(attr)).to.deep.equal(size)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('calls renderBox and nothing else', function (done) {
+      const renderer: Renderer = {
+        renderBox: () => done(),
+        renderLine: () => expect.fail(),
+        renderPath: () => expect.fail(),
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new BoxDrawable()
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position', function () {
+      const check = (position: Point): void => {
+        const renderer: Renderer = {
+          renderBox: (start) => {
+            expect(start).to.deep.equal(position)
+          },
+          renderLine: () => expect.fail(),
+          renderPath: () => expect.fail(),
+          renderText: () => expect.fail(),
+          measureText: () => Size.ZERO
+        }
+        const obj = new BoxDrawable()
+        obj.setTopLeft(position)
+        obj.draw(renderer)
+      }
+      check(new Point(0, 0))
+      check(new Point(-10, 15))
+      check(new Point(42.25, 37.75))
+    })
+  })
+})

--- a/test/diagram/drawables/component-head-drawable.test.ts
+++ b/test/diagram/drawables/component-head-drawable.test.ts
@@ -1,0 +1,71 @@
+import { ComponentHeadDrawable } from '../../../src/diagram/drawables/component-head-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+import { COMPONENT_HEAD_PADDING_H, COMPONENT_HEAD_PADDING_V } from '../../../src/diagram/config'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/component-head-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns size of name plus padding', function () {
+      const textSize = new Size(42.25, 37.75)
+      const expectedSize = new Size(42.25 + 2 * COMPONENT_HEAD_PADDING_H, 37.75 + 2 * COMPONENT_HEAD_PADDING_V)
+      const attr: RenderAttributes = {
+        measureText: (text: string) => {
+          expect(text).to.equal(' foo bar ')
+          return textSize
+        }
+      }
+      expect(new ComponentHeadDrawable(' foo bar ').measure(attr)).to.deep.equal(expectedSize)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('calls renderBox followed by renderText with name', function (done) {
+      let boxCalled = false
+      const renderer: Renderer = {
+        renderBox: () => {
+          expect(boxCalled).to.be.false
+          boxCalled = true
+        },
+        renderLine: () => expect.fail(),
+        renderPath: () => expect.fail(),
+        renderText: (text: string) => {
+          expect(boxCalled).to.be.true
+          expect(text).to.equal(' foo bar ')
+          done()
+        },
+        measureText: () => new Size(40, 15)
+      }
+      const obj = new ComponentHeadDrawable(' foo bar ')
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position and with correct size', function () {
+      const position = new Point(50, 100)
+
+      const textSize = new Size(40, 15)
+      const expectedSize = new Size(40 + 2 * COMPONENT_HEAD_PADDING_H, 15 + 2 * COMPONENT_HEAD_PADDING_V)
+
+      const expectedTextPosition = new Point(50 - textSize.width / 2, 100 + COMPONENT_HEAD_PADDING_V + textSize.height)
+
+      const renderer: Renderer = {
+        renderBox: (pos, size) => {
+          expect(pos.x).to.equal(position.x - expectedSize.width / 2)
+          expect(pos.y).to.equal(position.y)
+          expect(size).to.deep.equal(expectedSize)
+        },
+        renderLine: () => expect.fail(),
+        renderPath: () => expect.fail(),
+        renderText: (text: string, pos: Point) => {
+          expect(pos).to.deep.equal(expectedTextPosition)
+        },
+        measureText: () => textSize
+      }
+      const obj = new ComponentHeadDrawable('')
+      obj.setTopCenter(position)
+      obj.draw(renderer)
+    })
+  })
+})

--- a/test/diagram/drawables/lifeline-drawable.test.ts
+++ b/test/diagram/drawables/lifeline-drawable.test.ts
@@ -1,0 +1,99 @@
+import { LifelineDrawable } from '../../../src/diagram/drawables/lifeline-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+import { HeadDrawable } from '../../../src/diagram/drawables/head-drawable'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/lifeline-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns combined size of head and lifeline length', function () {
+      const head: HeadDrawable = {
+        setTopCenter: () => expect.fail(),
+        measure: () => new Size(40, 15),
+        draw: () => expect.fail()
+      }
+      const obj = new LifelineDrawable(head)
+      obj.setTopCenter(new Point(25, 75))
+      obj.setEndHeight(175)
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      expect(obj.measure(attr)).to.deep.equal(new Size(40, 100))
+    })
+  })
+
+  describe('#draw()', function () {
+    it('renders the head followed by lifeline line', function (done) {
+      let headCalled = false
+      const head: HeadDrawable = {
+        setTopCenter: () => {},
+        measure: () => new Size(40, 15),
+        draw: () => {
+          expect(headCalled).to.be.false
+          headCalled = true
+        }
+      }
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => {
+          expect(headCalled).to.be.true
+          done()
+        },
+        renderPath: () => expect.fail(),
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new LifelineDrawable(head)
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position', function () {
+      let topCenterCalled = false
+
+      const head: HeadDrawable = {
+        setTopCenter: (topCenter) => {
+          expect(topCenter).to.deep.equal(new Point(50, 100))
+          topCenterCalled = true
+        },
+        measure: () => new Size(40, 15),
+        draw: () => {
+          expect(topCenterCalled).to.be.true
+        }
+      }
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: (pos1, pos2) => {
+          expect(pos1).to.deep.equal(new Point(50, 115))
+          expect(pos2).to.deep.equal(new Point(50, 185))
+        },
+        renderPath: () => expect.fail(),
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new LifelineDrawable(head)
+      obj.setTopCenter(new Point(50, 100))
+      obj.setEndHeight(185)
+      obj.draw(renderer)
+    })
+  })
+
+  describe('#measureHead()', function () {
+    it('returns size of head', function () {
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      const size = new Size(40, 15)
+      const head: HeadDrawable = {
+        setTopCenter: () => expect.fail(),
+        measure: (a) => {
+          expect(a).to.equal(attr)
+          return size
+        },
+        draw: () => expect.fail()
+      }
+      expect(new LifelineDrawable(head).measureHead(attr)).to.deep.equal(size)
+    })
+  })
+})

--- a/test/diagram/drawables/stick-figure-drawable.test.ts
+++ b/test/diagram/drawables/stick-figure-drawable.test.ts
@@ -1,0 +1,53 @@
+import { StickFigureDrawable } from '../../../src/diagram/drawables/stick-figure-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/stick-figure-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns non-zero size', function () {
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      const result = new StickFigureDrawable().measure(attr)
+      expect(result.width).to.be.greaterThan(0)
+      expect(result.height).to.be.greaterThan(0)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('calls renderPath and nothing else', function (done) {
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPath: (data) => {
+          expect(data).to.be.a('string').with.length.greaterThan(0)
+          done()
+        },
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new StickFigureDrawable()
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position set by #setTopCenter()', function () {
+      const position = new Point(42.25, 37.75)
+      // eslint-disable-next-line prefer-const
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPath: (data, pos) => {
+          expect(pos).to.deep.equal(position)
+        },
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new StickFigureDrawable()
+      obj.setTopCenter(position)
+      obj.draw(renderer)
+    })
+  })
+})

--- a/test/diagram/drawables/text-drawable.test.ts
+++ b/test/diagram/drawables/text-drawable.test.ts
@@ -1,0 +1,69 @@
+import { TextAlignment, TextDrawable } from '../../../src/diagram/drawables/text-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+
+import { expect } from 'chai'
+
+describe('src/diagram/drawables/text-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('calls measureText with defined string and font size', function (done) {
+      const attr: RenderAttributes = {
+        measureText: (text: string, fontSize: number) => {
+          expect(text).to.equal(' foo bar ')
+          expect(fontSize).to.equal(14.5)
+          done()
+          return Size.ZERO
+        }
+      }
+      const obj = new TextDrawable(' foo bar ', 14.5)
+      obj.measure(attr)
+    })
+
+    it('returns the measured value', function () {
+      const size = new Size(42.25, 37.75)
+      const attr: RenderAttributes = {
+        measureText: () => size
+      }
+      expect(new TextDrawable(' foo bar ', 14.5).measure(attr)).to.deep.equal(size)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('calls renderText and nothing else', function (done) {
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPath: () => expect.fail(),
+        renderText: (text: string, position: Point, fontSize: number) => {
+          expect(text).to.equal(' foo bar ')
+          expect(fontSize).to.equal(14.5)
+          done()
+        },
+        measureText: () => new Size(40, 15)
+      }
+      const obj = new TextDrawable(' foo bar ', 14.5)
+      obj.draw(renderer)
+    })
+
+    it('renders at correct position', function () {
+      const check = (align: TextAlignment, expected: Point): void => {
+        const renderer: Renderer = {
+          renderBox: () => expect.fail(),
+          renderLine: () => expect.fail(),
+          renderPath: () => expect.fail(),
+          renderText: (text: string, position: Point) => {
+            expect(position).to.deep.equal(expected)
+          },
+          measureText: () => new Size(40, 15)
+        }
+        const obj = new TextDrawable('', 12)
+        obj.setPosition(new Point(50, 100), align)
+        obj.draw(renderer)
+      }
+      check(TextAlignment.CENTER_CENTER, new Point(30, 107.5))
+      check(TextAlignment.CENTER_ABOVE, new Point(30, 100))
+      check(TextAlignment.CENTER_BELOW, new Point(30, 115))
+    })
+  })
+})


### PR DESCRIPTION
This adds a Drawable interface for things that can be measured and rendered. Drawables can be composited (a Drawable can itself include other Drawables in size computation and when rendering).

A few Drawable-extending classes are implemented related to drawing entities.