### PR TITLE
chore: Setup JSDoc linter; remove types doc comments

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,11 @@
-extends: 'standard-with-typescript'
+extends:
+  - 'standard-with-typescript'
+  - 'plugin:jsdoc/recommended'
+
 parserOptions:
   project: './tsconfig.json'
+
+rules:
+  'jsdoc/require-param-type': off
+  'jsdoc/require-returns-type': off
+  'jsdoc/no-types': error

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,13 @@ import { parse } from './src/parser/parser'
 export { tokenize } from './src/tokenizer/tokenizer'
 export { parse } from './src/parser/parser'
 
+/**
+ * Given an input string containing the sequence specification, perform a full tokenize and parse
+ * to obtain the resulting sequence.
+ *
+ * @param input The input code.
+ * @returns The parsed sequence.
+ */
 export function compileToSequence (input: string): Sequence {
   const tokens = tokenize(input)
   return parse(tokens)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint": "^7.28.0",
         "eslint-config-standard-with-typescript": "^20.0.0",
         "eslint-plugin-import": "^2.23.4",
+        "eslint-plugin-jsdoc": "^35.4.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "mocha": "^8.4.0",
@@ -489,6 +490,20 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.9.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.9.0-alpha.1.tgz",
+      "integrity": "sha512-Clxxc0PwpISoYYBibA+1L2qFJ7gvFVhI2Hos87S06K+Q0cXdOhZQJNKWuaQGPAeHjZEuUB/YoWOfwjuF2wirqA==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.1.6-beta.0",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "1.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1267,6 +1282,15 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.1.6-beta.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.6-beta.0.tgz",
+      "integrity": "sha512-q3cA8TSMyqW7wcPSYWzbO/rMahnXgzs4SLG/UIWXdEsnXTFPZkEkWAdNgPiHig2OzxgpPLOh4WwsmClDxndwHw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1764,6 +1788,46 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "35.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
+      "integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "^0.9.0-alpha.1",
+        "comment-parser": "1.1.6-beta.0",
+        "debug": "^4.3.2",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "^1.0.4",
+        "lodash": "^4.17.21",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -2914,6 +2978,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.0.4.tgz",
+      "integrity": "sha512-jzmW9gokeq9+bHPDR1nCeidMyFUikdZlbOhKzh9+/nJqB75XhpNKec1/UuxW5c4+O+Pi31Gc/dCboyfSm/pSpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3953,6 +4026,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/release-zalgo": {
@@ -5192,6 +5274,17 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.9.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.9.0-alpha.1.tgz",
+      "integrity": "sha512-Clxxc0PwpISoYYBibA+1L2qFJ7gvFVhI2Hos87S06K+Q0cXdOhZQJNKWuaQGPAeHjZEuUB/YoWOfwjuF2wirqA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.1.6-beta.0",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "1.0.4"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
@@ -5742,6 +5835,12 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.1.6-beta.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.6-beta.0.tgz",
+      "integrity": "sha512-q3cA8TSMyqW7wcPSYWzbO/rMahnXgzs4SLG/UIWXdEsnXTFPZkEkWAdNgPiHig2OzxgpPLOh4WwsmClDxndwHw==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6141,6 +6240,34 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "35.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
+      "integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "^0.9.0-alpha.1",
+        "comment-parser": "1.1.6-beta.0",
+        "debug": "^4.3.2",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "^1.0.4",
+        "lodash": "^4.17.21",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         }
       }
     },
@@ -6951,6 +7078,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.0.4.tgz",
+      "integrity": "sha512-jzmW9gokeq9+bHPDR1nCeidMyFUikdZlbOhKzh9+/nJqB75XhpNKec1/UuxW5c4+O+Pi31Gc/dCboyfSm/pSpQ==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7732,6 +7865,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
       "dev": true
     },
     "release-zalgo": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^7.28.0",
     "eslint-config-standard-with-typescript": "^20.0.0",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-jsdoc": "^35.4.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "mocha": "^8.4.0",

--- a/src/diagram/drawables/box-drawable.ts
+++ b/src/diagram/drawables/box-drawable.ts
@@ -19,7 +19,7 @@ export class BoxDrawable implements Drawable {
    * Set the size of the rectangle.
    * This needs to be called before measurement.
    *
-   * @param {Size} size The size.
+   * @param size The size.
    */
   setSize (size: Size): void {
     this.size = size
@@ -29,7 +29,7 @@ export class BoxDrawable implements Drawable {
    * Set the position of this rectangle via the top-left corner.
    * The box expands downwards and to the right from this location.
    *
-   * @param {Point} start The position.
+   * @param start The position.
    */
   setTopLeft (start: Point): void {
     this.start = start

--- a/src/diagram/drawables/lifeline-drawable.ts
+++ b/src/diagram/drawables/lifeline-drawable.ts
@@ -24,7 +24,7 @@ export class LifelineDrawable implements Drawable {
    * The y coordinate determines the height below which the head (and, later, the lifeline line) appear.
    * The x coordinate determines the center location of the lifeline.
    *
-   * @param {Point} position The position.
+   * @param position The position.
    */
   setTopCenter (position: Point): void {
     this.position = position
@@ -34,7 +34,7 @@ export class LifelineDrawable implements Drawable {
    * Set the y coordinate at which the lifeline stops. This is an absolute coordinate,
    * independent of the lifeline's anchor position.
    *
-   * @param {number} endHeight The absolute height at which the lifeline stops.
+   * @param endHeight The absolute height at which the lifeline stops.
    */
   setEndHeight (endHeight: number): void {
     this.endHeight = endHeight
@@ -44,7 +44,8 @@ export class LifelineDrawable implements Drawable {
    * Measure just the head portion of this lifeline.
    * This is useful for laying out the lifeline, because #measure() would include the line length.
    *
-   * @param {object} attr The rendering attributes.
+   * @param attr The rendering attributes.
+   * @returns The head size.
    */
   measureHead (attr: RenderAttributes): Size {
     return this.head.measure(attr)

--- a/src/diagram/drawables/stick-figure-drawable.ts
+++ b/src/diagram/drawables/stick-figure-drawable.ts
@@ -16,7 +16,7 @@ export class StickFigureDrawable implements Drawable {
    * The position specifies the y-height for the top edge of the pictogram
    * and the x position for the center of the pictogram.
    *
-   * @param {Point} topCenter The position.
+   * @param topCenter The position.
    */
   setTopCenter (topCenter: Point): void {
     this.topCenter = topCenter

--- a/src/diagram/drawables/text-drawable.ts
+++ b/src/diagram/drawables/text-drawable.ts
@@ -21,6 +21,13 @@ interface Offset {
   y: number
 }
 
+/**
+ * Determine how far the text position should be offset to account for its alignment.
+ *
+ * @param align The text alignment.
+ * @param textSize The size of the text.
+ * @returns The computed offset.
+ */
 function getOffsetForAlignment (align: TextAlignment, textSize: Size): Offset {
   switch (align) {
     case TextAlignment.CENTER_ABOVE:
@@ -54,8 +61,8 @@ export class TextDrawable implements Drawable {
    * The alignment might have the text centered around the given point,
    * aligned flush to one of its edges, etc.
    *
-   * @param {Point} pos The position.
-   * @param {TextAlignment} align The alignment specifier.
+   * @param pos The position.
+   * @param align The alignment specifier.
    */
   setPosition (pos: Point, align: TextAlignment): void {
     this.position = pos

--- a/src/parser/entity/parse-entity-options.ts
+++ b/src/parser/entity/parse-entity-options.ts
@@ -4,6 +4,14 @@ import { entityOptions } from '../strings'
 import { defaultEntityOptions, EntityOptions } from './entity-options'
 import { TokenAccessor } from '../token-accessor'
 
+/**
+ * Given an option string and an options object, apply the string to the object.
+ * A token is passed as reference (mostly for error reporting).
+ *
+ * @param token The reference token.
+ * @param option The option to apply.
+ * @param obj The object to apply the option to.
+ */
 function applyOption (token: Token, option: string, obj: EntityOptions): void {
   if (option === entityOptions.actor) {
     obj.isActor = true
@@ -12,6 +20,12 @@ function applyOption (token: Token, option: string, obj: EntityOptions): void {
   throw new UnsupportedOptionError(token, option, [entityOptions.actor])
 }
 
+/**
+ * Read entity options from the given stream.
+ *
+ * @param tokens The token stream.
+ * @returns The options that were read.
+ */
 function getOptions (tokens: TokenAccessor): EntityOptions {
   const set = new Set<string>()
   const options: EntityOptions = { ...defaultEntityOptions }
@@ -30,8 +44,8 @@ function getOptions (tokens: TokenAccessor): EntityOptions {
  * Determine whether the given token marks the beginning of entity options.
  * This will only produce valid results for tokens at the correct position within entity definitions.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token could be parsed as entity options.
+ * @param token The next token in the input stream.
+ * @returns Whether the token could be parsed as entity options.
  */
 export function detectEntityOptions (token: Token): boolean {
   return token.type === TokenType.PAREN_LEFT
@@ -40,8 +54,8 @@ export function detectEntityOptions (token: Token): boolean {
 /**
  * Force-parse entity options from the given stream.
  *
- * @param {TokenAccessor} tokens The input stream.
- * @returns {EntityOptions} The parsed options.
+ * @param tokens The input stream.
+ * @returns The parsed options.
  */
 export function parseEntityOptions (tokens: TokenAccessor): EntityOptions {
   tokens.pop(TokenType.PAREN_LEFT)

--- a/src/parser/entity/parse-entity.ts
+++ b/src/parser/entity/parse-entity.ts
@@ -10,8 +10,8 @@ import { TokenAccessor } from '../token-accessor'
  * Determine whether the given token marks the beginning of an entity definition.
  * This will only produce valid results for tokens at global scope.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token could be parsed as an entity definition.
+ * @param token The next token in the input stream.
+ * @returns Whether the token could be parsed as an entity definition.
  */
 export function detectEntity (token: Token): boolean {
   return token.type === TokenType.WORD && token.value === keywords.object
@@ -20,8 +20,8 @@ export function detectEntity (token: Token): boolean {
 /**
  * Force-parse an entity definition from the given stream.
  *
- * @param {TokenAccessor} tokens The input stream.
- * @returns {Entity} The parsed entity.
+ * @param tokens The input stream.
+ * @returns The parsed entity.
  */
 export function parseEntity (tokens: TokenAccessor): Entity {
   tokens.pop(TokenType.WORD, keywords.object)

--- a/src/parser/message/parse-message-block.ts
+++ b/src/parser/message/parse-message-block.ts
@@ -49,8 +49,8 @@ class MessageBlockBuilder {
  * Determine whether the given token marks the beginning of a message block.
  * This will only produce valid results when right at the end of a message description.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token (and what follows) could be parsed as a message block.
+ * @param token The next token in the input stream.
+ * @returns Whether the token (and what follows) could be parsed as a message block.
  */
 export function detectMessageBlock (token: Token): boolean {
   return token.type === TokenType.BLOCK_LEFT
@@ -64,11 +64,11 @@ export function detectMessageBlock (token: Token): boolean {
  * for the specific message type. It does, however, include "evidence" (a token) for the return value if one exists so
  * meaningful error messages can be created later.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @param {EntityLookup} entities A way of resolving entity ids.
- * @param {Entity} active The entity that was targeted by the message to which this block belongs.
- * @returns {object} The parsed message description.
- * @throws {ParserError} If a check fails.
+ * @param tokens The token stream.
+ * @param entities A way of resolving entity ids.
+ * @param active The entity that was targeted by the message to which this block belongs.
+ * @returns The parsed message description.
+ * @throws If a check fails.
  */
 export function parseMessageBlock (tokens: TokenAccessor, entities: EntityLookup, active: Entity): MessageBlock {
   tokens.pop(TokenType.BLOCK_LEFT)

--- a/src/parser/message/parse-message-description.ts
+++ b/src/parser/message/parse-message-description.ts
@@ -26,8 +26,8 @@ interface OptionalValueWithEvidence<T> {
 /**
  * Determine whether the message begins with '*'. If yes, value will be true, and false otherwise.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @returns {object} The Boolean value and evidence for it if possible.
+ * @param tokens The token stream.
+ * @returns The Boolean value and evidence for it if possible.
  */
 function determineFromOutside (tokens: TokenAccessor): OptionalValueWithEvidence<boolean> {
   const evidence = tokens.popOptional(TokenType.WORD, keywords.outside)
@@ -38,8 +38,8 @@ function determineFromOutside (tokens: TokenAccessor): OptionalValueWithEvidence
  * Determine the type of message (sync, async, ...) specified in parentheses.
  * If no type was specified, value will be undefined.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @returns {object} The message type and evidence for it if possible.
+ * @param tokens The token stream.
+ * @returns The message type and evidence for it if possible.
  */
 function determineType (tokens: TokenAccessor): OptionalValueWithEvidence<MessageType> {
   if (tokens.popOptional(TokenType.PAREN_LEFT) != null) {
@@ -57,9 +57,9 @@ function determineType (tokens: TokenAccessor): OptionalValueWithEvidence<Messag
 /**
  * Determine the message target. This will be an entity if one was specified, and undefined if '*' was given.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @param {EntityLookup} entities A way of resolving entity ids.
- * @returns {object} The target and evidence for it if possible.
+ * @param tokens The token stream.
+ * @param entities A way of resolving entity ids.
+ * @returns The target and evidence for it if possible.
  */
 function determineTarget (tokens: TokenAccessor, entities: EntityLookup): OptionalValueWithEvidence<Entity> {
   const evidence = tokens.pop(TokenType.WORD)
@@ -76,8 +76,8 @@ function determineTarget (tokens: TokenAccessor, entities: EntityLookup): Option
 /**
  * Determine the message label. If no label was specified, the value will be undefined.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @returns {object} The message label and evidence for it if possible.
+ * @param tokens The token stream.
+ * @returns The message label and evidence for it if possible.
  */
 function determineLabel (tokens: TokenAccessor): OptionalValueWithEvidence<string> {
   const evidence = tokens.popOptional(TokenType.STRING)
@@ -91,10 +91,10 @@ function determineLabel (tokens: TokenAccessor): OptionalValueWithEvidence<strin
  * Determine the message block (nested messages). If no block exists, the value will be undefined.
  * If a block exists but the target is null, this will throw an error.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @param {EntityLookup} entities A way of resolving entity ids.
- * @param {Entity | undefined} target The already-resolved message target.
- * @returns {object} The message label and evidence for it if possible.
+ * @param tokens The token stream.
+ * @param entities A way of resolving entity ids.
+ * @param target The already-resolved message target.
+ * @returns The message label and evidence for it if possible.
  */
 function determineBlock (tokens: TokenAccessor, entities: EntityLookup, target: Entity | undefined): OptionalValueWithEvidence<MessageBlock> {
   const evidence = tokens.hasNext() ? tokens.peek() : undefined
@@ -111,8 +111,8 @@ function determineBlock (tokens: TokenAccessor, entities: EntityLookup, target: 
  * Determine whether the given token marks the beginning of a message description.
  * This will only produce valid results when on global level or inside a message block.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token (and what follows) could be parsed as a message description.
+ * @param token The next token in the input stream.
+ * @returns Whether the token (and what follows) could be parsed as a message description.
  */
 export function detectMessageDescription (token: Token): boolean {
   return token.type === TokenType.ARROW || (token.type === TokenType.WORD && token.value === keywords.outside)
@@ -128,10 +128,10 @@ export function detectMessageDescription (token: Token): boolean {
  * This is the token that caused that value to be detected (or not to be detected) and allows for meaningful error
  * messages to be created later.
  *
- * @param {TokenAccessor} tokens The token stream.
- * @param {EntityLookup} entities A way of resolving entity ids.
- * @returns {object} The parsed message description.
- * @throws {ParserError} If a check fails.
+ * @param tokens The token stream.
+ * @param entities A way of resolving entity ids.
+ * @returns The parsed message description.
+ * @throws If a check fails.
  */
 export function parseMessageDescription (tokens: TokenAccessor, entities: EntityLookup): MessageDescription {
   // parse the following format, where [...] indicates optionality and target is an entity or '*':

--- a/src/parser/message/parse-message.ts
+++ b/src/parser/message/parse-message.ts
@@ -13,8 +13,8 @@ import { matchRegularMessage } from './species/match-regular-message'
  * Determine whether the given token marks the beginning of a message.
  * This will only produce valid results when on global level or inside a message block.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token (and what follows) could be parsed as a message.
+ * @param token The next token in the input stream.
+ * @returns Whether the token (and what follows) could be parsed as a message.
  */
 export function detectMessage (token: Token): boolean {
   return detectMessageDescription(token)
@@ -24,11 +24,11 @@ export function detectMessage (token: Token): boolean {
  * Force-parse a message including full validity and type checks.
  * This can parse found messages, lost messages, and regular messages (with two participating entities).
  *
- * @param {TokenAccessor} tokens The token stream.
- * @param {EntityLookup} entities A way of resolving entity ids.
- * @param {Entity | undefined} active The entity that was targeted by the parent message, if any.
- * @returns {object} The parsed message description.
- * @throws {ParserError} If a check fails.
+ * @param tokens The token stream.
+ * @param entities A way of resolving entity ids.
+ * @param active The entity that was targeted by the parent message, if any.
+ * @returns The parsed message description.
+ * @throws If a check fails.
  */
 export function parseMessage (tokens: TokenAccessor, entities: EntityLookup, active: Entity | undefined): Activation {
   /*

--- a/src/parser/message/parse-return.ts
+++ b/src/parser/message/parse-return.ts
@@ -7,8 +7,8 @@ import { TokenAccessor } from '../token-accessor'
  * Determine whether the given token marks the beginning of a return statement.
  * This will only produce valid results when inside a message block.
  *
- * @param {Token} token The next token in the input stream.
- * @returns {boolean} Whether the token (and what follows) could be parsed as a return statement.
+ * @param token The next token in the input stream.
+ * @returns Whether the token (and what follows) could be parsed as a return statement.
  */
 export function detectReturn (token: Token): boolean {
   return token.type === TokenType.WORD && token.value === keywords.return
@@ -17,8 +17,8 @@ export function detectReturn (token: Token): boolean {
 /**
  * Force-parse a return statement from the given stream.
  *
- * @param {TokenAccessor} tokens The input stream.
- * @returns {string} The return value.
+ * @param tokens The input stream.
+ * @returns The return value.
  */
 export function parseReturn (tokens: TokenAccessor): string {
   tokens.pop(TokenType.WORD, keywords.return)

--- a/src/parser/message/species/match-found-message.ts
+++ b/src/parser/message/species/match-found-message.ts
@@ -10,8 +10,8 @@ import { FoundMessage } from '../../../sequence/message'
  * Errors will be thrown if further constraints are violated.
  * If it does not match (message has no source or has a target), undefined will be returned.
  *
- * @param {object} desc The message description to match.
- * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ * @param desc The message description to match.
+ * @returns The activation created as a result of the match, or undefined.
  */
 export function matchFoundMessage (desc: MessageDescription): Activation | undefined {
   const { type, fromOutside, target, label, block, evidence } = desc

--- a/src/parser/message/species/match-lost-message.ts
+++ b/src/parser/message/species/match-lost-message.ts
@@ -11,9 +11,9 @@ import { messageOptions } from '../../strings'
  * Errors will be thrown if further constraints are violated.
  * If it does not match (message has no source or has a target), undefined will be returned.
  *
- * @param {object} desc The message description to match.
- * @param {Entity} active The entity that is the target of the parent message, if any.
- * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ * @param desc The message description to match.
+ * @param active The entity that is the target of the parent message, if any.
+ * @returns The activation created as a result of the match, or undefined.
  */
 export function matchLostMessage (desc: MessageDescription, active: Entity | undefined): Activation | undefined {
   const { type, fromOutside, target, label, block, evidence } = desc

--- a/src/parser/message/species/match-regular-message.ts
+++ b/src/parser/message/species/match-regular-message.ts
@@ -65,8 +65,8 @@ const destroyDefinition: ActivationDefinition = {
  * Depending on the message type, activations have to be created differently.
  * This function chooses the correct definition for the given type.
  *
- * @param {MessageType} messageType The message type.
- * @returns {object} The definition for that type.
+ * @param messageType The message type.
+ * @returns The definition for that type.
  */
 function lookupDefinition (messageType: MessageType): ActivationDefinition {
   // this switch is complete, otherwise TypeScript would complain
@@ -88,9 +88,9 @@ function lookupDefinition (messageType: MessageType): ActivationDefinition {
  * Errors will be thrown if further constraints are violated.
  * If it does not match (message has no source or no target), undefined will be returned.
  *
- * @param {object} desc The message description to match.
- * @param {Entity} active The entity that is the target of the parent message, if any.
- * @returns {Activation | undefined} The activation created as a result of the match, or undefined.
+ * @param desc The message description to match.
+ * @param active The entity that is the target of the parent message, if any.
+ * @returns The activation created as a result of the match, or undefined.
  */
 export function matchRegularMessage (desc: MessageDescription, active: Entity | undefined): Activation | undefined {
   const { type, fromOutside, target, label, block, evidence } = desc

--- a/src/parser/parser-state.ts
+++ b/src/parser/parser-state.ts
@@ -27,8 +27,7 @@ export class ParserState implements EntityLookup {
   /**
    * Add the given entity to this state.
    *
-   * @param {Entity} entity The entity.
-   * @returns {void}
+   * @param entity The entity.
    */
   insertEntity (entity: Entity): void {
     if (this.entityMap.has(entity.id)) {
@@ -42,8 +41,7 @@ export class ParserState implements EntityLookup {
    * Add the given activation to this state. The activation must be a top-level activation,
    * in other words, child activations should not be added with this.
    *
-   * @param {Activation} activation The activation.
-   * @returns {void}
+   * @param activation The activation.
    */
   insertActivation (activation: Activation): void {
     this.rootActivations.push(activation)
@@ -52,7 +50,7 @@ export class ParserState implements EntityLookup {
   /**
    * Retrieve all entities currently added to this state object.
    *
-   * @returns {Entity[]} The entities.
+   * @returns The entities.
    */
   getEntities (): Entity[] {
     return this.entities
@@ -62,7 +60,7 @@ export class ParserState implements EntityLookup {
    * Retrieve all activations currently added to this state object.
    * This does not consider child activations, but gives a flat view of just the root activations.
    *
-   * @returns {Activation[]} The activations.
+   * @returns The activations.
    */
   getRootActivations (): Activation[] {
     return this.rootActivations

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -12,9 +12,9 @@ import { detectMessage, parseMessage } from './message/parse-message'
  * This expects the stream to contain a completely valid document, otherwise an error will be thrown when there
  * is a token mismatch.
  *
- * @param {TokenStream} tokens The input token stream as produced by the tokenizer.
- * @returns {Sequence} The parsed sequence.
- * @throws {ParserError} If an error occurs during parsing.
+ * @param tokens The input token stream as produced by the tokenizer.
+ * @returns The parsed sequence.
+ * @throws If an error occurs during parsing.
  */
 export function parse (tokens: TokenStream): Sequence {
   const state = new ParserState()

--- a/src/parser/token-accessor.ts
+++ b/src/parser/token-accessor.ts
@@ -30,7 +30,7 @@ export class TokenAccessor {
   /**
    * Check stream state.
    *
-   * @returns {boolean} Whether there are any more tokens left.
+   * @returns Whether there are any more tokens left.
    */
   hasNext (): boolean {
     this.advanceSkippedTokens()
@@ -40,8 +40,8 @@ export class TokenAccessor {
   /**
    * Retrieve the next token without advancing the stream.
    *
-   * @returns {Token} The next token in the stream.
-   * @throws {EndOfStreamError} If there is no remaining token.
+   * @returns The next token in the stream.
+   * @throws If there is no remaining token.
    */
   peek (): Token {
     this.advanceSkippedTokens()
@@ -55,9 +55,9 @@ export class TokenAccessor {
    *
    * If no token remains (empty stream), this will return undefined.
    *
-   * @param {TokenType} type The type of token to pop off.
-   * @param {?string} value The value the token is expected to have.
-   * @returns {Token | undefined} The next token in the stream, or undefined.
+   * @param type The type of token to pop off.
+   * @param value The value the token is expected to have.
+   * @returns The next token in the stream, or undefined.
    */
   popOptional (type: TokenType, value?: string): Token | undefined {
     if (!this.hasNext()) {
@@ -74,11 +74,11 @@ export class TokenAccessor {
    * Obtain the next token and advance the stream. The token must be of the given type,
    * otherwise an error will be thrown. Optionally, the token value can be asserted in the same manner.
    *
-   * @param {TokenType} type The type of token to pop off.
-   * @param {?string} value The value the token is expected to have.
-   * @returns {Token} The next token.
-   * @throws {EndOfStreamError} If there is no remaining token.
-   * @throws {UnexpectedTokenError} If the token type mismatches, or a value was specified and it mismatches.
+   * @param type The type of token to pop off.
+   * @param value The value the token is expected to have.
+   * @returns The next token.
+   * @throws If there is no remaining token.
+   * @throws If the token type mismatches, or a value was specified and it mismatches.
    */
   pop (type: TokenType, value?: string): Token {
     const optToken = this.popOptional(type, value)

--- a/src/parser/unquote.ts
+++ b/src/parser/unquote.ts
@@ -3,8 +3,8 @@ import { Token, TokenType } from '../tokenizer/token'
 /**
  * Unquote the given string token, returning its true value.
  *
- * @param {string} stringToken The token, which must have type STRING.
- * @returns {string} The unquoted value.
+ * @param stringToken The token, which must have type STRING.
+ * @returns The unquoted value.
  */
 export function unquote (stringToken: Token): string {
   if (stringToken.type !== TokenType.STRING) {

--- a/src/renderer/browser-svg/browser-svg-renderer.ts
+++ b/src/renderer/browser-svg/browser-svg-renderer.ts
@@ -4,10 +4,23 @@ import { Point } from '../../util/geometry/point'
 
 type AttributeValue = string | number | undefined
 
+/**
+ * Create an XML element for the SVG namespace.
+ *
+ * @param tagName The tag name for the element to create.
+ * @returns The created element.
+ */
 function createSvgElement (tagName: string): SVGElement {
   return document.createElementNS('http://www.w3.org/2000/svg', tagName)
 }
 
+/**
+ * Apply a set of attributes to the given element.
+ * The attribute values (when present) will be converted to strings.
+ *
+ * @param element The SVG element.
+ * @param attrs The attributes to apply.
+ */
 function applyAttributes (element: SVGElement, attrs: Record<string, AttributeValue>): void {
   for (const key of Object.keys(attrs)) {
     const value = attrs[key]
@@ -16,6 +29,14 @@ function applyAttributes (element: SVGElement, attrs: Record<string, AttributeVa
   }
 }
 
+/**
+ * Obtain the size of the given piece of text in SVG pixels.
+ * This is potentially an expensive operation.
+ *
+ * @param text The text to measure.
+ * @param fontSize The font size to use while measuring.
+ * @returns The size of the text in the SVG context.
+ */
 function measureText (text: string, fontSize: number): Size {
   const element = createSvgElement('text') as SVGTextElement
   applyAttributes(element, {
@@ -33,6 +54,14 @@ function measureText (text: string, fontSize: number): Size {
   return new Size(box.width, box.height)
 }
 
+/**
+ * Create a viewBox attribute string from the given canvas size and external padding.
+ *
+ * @param size The canvas size.
+ * @param hPadding The padding to apply on the left and right sides.
+ * @param vPadding The padding to apply on the top and bottom sides.
+ * @returns A viewBox string that matches the specifications.
+ */
 function getViewBox (size: Size, hPadding: number, vPadding: number): string {
   const minX = -hPadding
   const minY = -vPadding
@@ -42,6 +71,12 @@ function getViewBox (size: Size, hPadding: number, vPadding: number): string {
   return `${minX} ${minY} ${width} ${height}`
 }
 
+/**
+ * Given a StrokeOptions specification, compute the required attributes to apply.
+ *
+ * @param options The stroke options.
+ * @returns The attributes that need to be applied to achieve that stroke.
+ */
 function convertStrokeToAttributes (options?: StrokeOptions): Record<string, AttributeValue> {
   return {
     'stroke-width': options?.lineWidth ?? 1,
@@ -83,9 +118,8 @@ export class BrowserSvgRenderer implements DirectRenderer<SVGSVGElement> {
    * Any CSS color value can be used.
    * The background is used for rendering boxes, and the foreground for strokes and texts.
    *
-   * @param {string} foreground The foreground color.
-   * @param {string} background The background color.
-   * @returns {void}
+   * @param foreground The foreground color.
+   * @param background The background color.
    */
   setColors (foreground: string, background: string): void {
     this.foregroundColor = foreground

--- a/src/sequence/activation.ts
+++ b/src/sequence/activation.ts
@@ -1,5 +1,12 @@
 import { Message, MessageStyle } from './message'
 
+/**
+ * Determine whether the given reply is a valid reply to the given original message.
+ *
+ * @param message The original message.
+ * @param reply The assumed reply to that message.
+ * @returns Whether the reply makes sense in the context of the given message.
+ */
 function isReplyValid (message: Message, reply: Message): boolean {
   if (reply.style !== MessageStyle.REPLY) {
     return false

--- a/src/tokenizer/token-stream.ts
+++ b/src/tokenizer/token-stream.ts
@@ -17,7 +17,7 @@ export class TokenStream {
   /**
    * Check stream state.
    *
-   * @returns {boolean} Whether there are any more tokens left.
+   * @returns Whether there are any more tokens left.
    */
   hasNext (): boolean {
     return this.nextPointer < this.tokens.length
@@ -26,7 +26,7 @@ export class TokenStream {
   /**
    * Retrieve the next token without advancing the stream.
    *
-   * @returns {Token} The next token in the stream.
+   * @returns The next token in the stream.
    * @throws {EndOfStreamError} If there is no remaining token.
    */
   peek (): Token {
@@ -39,7 +39,7 @@ export class TokenStream {
   /**
    * Obtain the next token in the stream, consuming it.
    *
-   * @returns {Token} The next token in the stream.
+   * @returns The next token in the stream.
    * @throws {EndOfStreamError} If there is no remaining token.
    */
   next (): Token {

--- a/src/tokenizer/tokenizer.ts
+++ b/src/tokenizer/tokenizer.ts
@@ -27,9 +27,9 @@ const TOKEN_END_REGEXP = /[\s=(){}:"]|->/
  * Try matching the input as a comment.
  * Anything is considered a comment that starts with the hash character ('#').
  *
- * @param {string} str The input.
- * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
+ * @param str The input.
+ * @param start The current position in the input string (start of the token to match).
+ * @returns The matched token, or undefined if not of the correct format.
  */
 function tryMatchComment (str: string, start: number): Token | undefined {
   if (str[start] === '#') {
@@ -43,9 +43,9 @@ function tryMatchComment (str: string, start: number): Token | undefined {
  * Try matching the input against the fixed token types.
  * A token type is considered "fixed" if its tokens can only ever have one specific value.
  *
- * @param {string} str The input.
- * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
+ * @param str The input.
+ * @param start The current position in the input string (start of the token to match).
+ * @returns The matched token, or undefined if not of the correct format.
  */
 function tryMatchFixed (str: string, start: number): Token | undefined {
   for (const fixed of Object.keys(FIXED_TYPES)) {
@@ -60,10 +60,10 @@ function tryMatchFixed (str: string, start: number): Token | undefined {
  * Try matching the input as a string.
  * Anything is considered a string that starts with a quotation mark ('"').
  *
- * @param {string} str The input.
- * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
- * @throws {UnterminatedStringError} If the matched string is left unterminated.
+ * @param str The input.
+ * @param start The current position in the input string (start of the token to match).
+ * @returns The matched token, or undefined if not of the correct format.
+ * @throws If the matched string is left unterminated.
  */
 function tryMatchString (str: string, start: number): Token | undefined {
   if (str[start] === '"') {
@@ -81,9 +81,9 @@ function tryMatchString (str: string, start: number): Token | undefined {
  * Try matching the input as a word.
  * A word is any sequence of regular characters up until the next whitespace, string token, or fixed token.
  *
- * @param {string} str The input.
- * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token | undefined} The matched token, or undefined if not of the correct format.
+ * @param str The input.
+ * @param start The current position in the input string (start of the token to match).
+ * @returns The matched token, or undefined if not of the correct format.
  */
 function tryMatchWord (str: string, start: number): Token | undefined {
   let end = regexpIndexOf(str, TOKEN_END_REGEXP, start)
@@ -96,11 +96,11 @@ function tryMatchWord (str: string, start: number): Token | undefined {
 /**
  * Match the next token form the input string, starting at the given position.
  *
- * @param {string} str The input.
- * @param {number} start The current position in the input string (start of the token to match).
- * @returns {Token} The matched token.
- * @throws {UnknownTokenTypeError} If the type of token could not be determined.
- * @throws {UnterminatedStringError} If the matched token is a string that is left unterminated.
+ * @param str The input.
+ * @param start The current position in the input string (start of the token to match).
+ * @returns The matched token.
+ * @throws If the type of token could not be determined.
+ * @throws If the matched token is a string that is left unterminated.
  */
 function matchToken (str: string, start: number): Token {
   const match = tryMatchComment(str, start) ??
@@ -118,10 +118,10 @@ function matchToken (str: string, start: number): Token {
 /**
  * Convert the given string into a stream of tokens.
  *
- * @param {string} str The input.
- * @returns {TokenStream} The tokenize result.
- * @throws {UnknownTokenTypeError} If the string includes a token whose type cannot be determined.
- * @throws {UnterminatedStringError} If the string includes a token that is left unterminated.
+ * @param str The input.
+ * @returns The tokenize result.
+ * @throws If the string includes a token whose type cannot be determined.
+ * @throws If the string includes a token that is left unterminated.
  */
 export function tokenize (str: string): TokenStream {
   const tokens: Token[] = []

--- a/src/util/find-end-of-line.ts
+++ b/src/util/find-end-of-line.ts
@@ -3,9 +3,9 @@
  * If no such character exists, the line is assumed to end at the string end, and str.length is returned.
  *
  *
- * @param {string} str The subject.
- * @param {?number} position Optionally, a start index.
- * @returns {number} The position of the next end-of-line character, or, in absence of one, str.length.
+ * @param str The subject.
+ * @param position Optionally, a start index.
+ * @returns The position of the next end-of-line character, or, in absence of one, str.length.
  */
 export function findEndOfLine (str: string, position?: number): number {
   const nPos = str.indexOf('\n', position)

--- a/src/util/geometry/point.ts
+++ b/src/util/geometry/point.ts
@@ -15,9 +15,9 @@ export class Point {
   /**
    * Create a new point whose coordinates are the sum of this one's and the given deltas.
    *
-   * @param {number} dx The amount to add on the x-axis.
-   * @param {number} dy The amount to add on the y-axis.
-   * @returns {Point} A new Point object with the shifted coordinates.
+   * @param dx The amount to add on the x-axis.
+   * @param dy The amount to add on the y-axis.
+   * @returns A new Point object with the shifted coordinates.
    */
   translate (dx: number, dy: number): Point {
     return new Point(this.x + dx, this.y + dy)
@@ -26,8 +26,8 @@ export class Point {
   /**
    * Create a copy of this point where the Y coordinate is the same, but the X coordinate is set to the one given.
    *
-   * @param {number} x The new x coordinate.
-   * @returns {Point} A new Point with the coordinates set as described above.
+   * @param x The new x coordinate.
+   * @returns A new Point with the coordinates set as described above.
    */
   withX (x: number): Point {
     return new Point(x, this.y)
@@ -36,8 +36,8 @@ export class Point {
   /**
    * Create a copy of this point where the X coordinate is the same, but the Y coordinate is set to the one given.
    *
-   * @param {number} y The new y coordinate.
-   * @returns {Point} A new Point with the coordinates set as described above.
+   * @param y The new y coordinate.
+   * @returns A new Point with the coordinates set as described above.
    */
   withY (y: number): Point {
     return new Point(this.x, y)

--- a/src/util/geometry/size.ts
+++ b/src/util/geometry/size.ts
@@ -18,9 +18,9 @@ export class Size {
   /**
    * Create a new object that is the sum of this one and the given deltas.
    *
-   * @param {number} dWidth The amount by which to grow this size width-wise.
-   * @param {number} dHeight The amount by which to grow this size height-wise.
-   * @returns {Size} A new Size object with the combined dimensions.
+   * @param dWidth The amount by which to grow this size width-wise.
+   * @param dHeight The amount by which to grow this size height-wise.
+   * @returns A new Size object with the combined dimensions.
    */
   add (dWidth: number, dHeight: number): Size {
     return new Size(this.width + dWidth, this.height + dHeight)

--- a/src/util/regexp-index-of.ts
+++ b/src/util/regexp-index-of.ts
@@ -2,10 +2,10 @@
  * Like String.prototype.indexOf(), but with a regular expression.
  * I.e. find the first matching index of the given RegExp, with the possibility to define a starting index.
  *
- * @param {string} str The subject.
- * @param {RegExp} regexp The regular expression to search for.
- * @param {?number} position Optionally, a start index.
- * @returns {number} The position at which the RegExp first matched, or -1 if no match was found.
+ * @param str The subject.
+ * @param regexp The regular expression to search for.
+ * @param position Optionally, a start index.
+ * @returns The position at which the RegExp first matched, or -1 if no match was found.
  */
 export function regexpIndexOf (str: string, regexp: RegExp, position?: number): number {
   // string.indexOf() treats positions < 0 as equal to 0


### PR DESCRIPTION
This sets up `eslint-plugin-jsdoc`, including configuration for TypeScript (no types in `@param`, `@returns` and other tags).
Types are removed from those tags where they appeared.