### PR TITLE
feat(diagram): Implement Diagram, EntityDiagramPart

### DIFF
--- a/src/diagram/config.ts
+++ b/src/diagram/config.ts
@@ -1,3 +1,5 @@
+export const ENTITY_SPACING = 16
+
 export const COMPONENT_HEAD_PADDING_H = 8
 export const COMPONENT_HEAD_PADDING_V = 12
 

--- a/src/diagram/diagram.ts
+++ b/src/diagram/diagram.ts
@@ -1,0 +1,90 @@
+import { Size } from '../util/geometry/size'
+import { Sequence } from '../sequence/sequence'
+import { RenderAttributes, Renderer } from '../renderer/renderer'
+import { EntityDiagramPart } from './parts/entity-diagram-part'
+import { ENTITY_SPACING } from './config'
+import { ConstraintLayout } from './layout/constraint-layout'
+import { TypedConstraintLayout } from './layout/typed-constraint-layout'
+import { Point } from '../util/geometry/point'
+
+/**
+ * Represents a visual diagram based on some sequence.
+ * In contrast to sequences themselves, instances of this class store very little in the sense of message hierarchies
+ * and script order, but are merely concerned with the visual parts that make up a sequence diagram.
+ * They can be laid out, sized, and drawn to a rendering surface.
+ */
+export class Diagram {
+  private readonly entities: EntityDiagramPart[]
+
+  private readonly horizontalLayout: ConstraintLayout<string>
+  private computedSize: Size | undefined
+
+  private constructor (entities: EntityDiagramPart[]) {
+    this.entities = entities
+
+    const entityIds = entities.map(e => e.entity.id)
+    this.horizontalLayout = new TypedConstraintLayout<string>(entityIds, {
+      itemMargin: ENTITY_SPACING
+    })
+  }
+
+  /**
+   * Build a diagram from the given sequence. The sequence must be fully valid.
+   *
+   * @param sequence The sequence to transform into a visual diagram.
+   * @returns The diagram that was built.
+   */
+  static create (sequence: Sequence): Diagram {
+    const entities = sequence.entities.map(e => new EntityDiagramPart(e))
+    return new Diagram(entities)
+  }
+
+  /**
+   * Layout the diagram parts with respect to each other, and compute overall diagram size.
+   *
+   * @param attr The rendering attributes used to determine e.g. the sizes of strings.
+   */
+  layout (attr: RenderAttributes): void {
+    for (const entity of this.entities) {
+      const head = entity.measureHead(attr)
+      this.horizontalLayout.applyDimension(entity.entity.id, head.width)
+    }
+
+    const computedLayout = this.horizontalLayout.compute()
+
+    // TODO replace with actual height once we have a vertical layout
+    this.computedSize = new Size(computedLayout.totalDimensions, 200)
+
+    for (const entity of this.entities) {
+      const posH = computedLayout.items.get(entity.entity.id)
+      if (posH == null) throw new Error('missing entity position')
+      entity.setTopCenter(new Point(posH.center, 0))
+    }
+  }
+
+  /**
+   * After #layout() has been called, this method can be used to obtain the overall computed size
+   * of the surface required for rendering the diagram.
+   *
+   * @returns The diagram size.
+   */
+  getComputedSize (): Size {
+    if (this.computedSize == null) {
+      throw new Error('layout not yet computed')
+    }
+    return this.computedSize
+  }
+
+  /**
+   * Draw this diagram with all its parts to the given renderer.
+   * The diagram has to be manually laid out prior to calling this method.
+   *
+   * @param renderer The renderer.
+   */
+  draw (renderer: Renderer): void {
+    if (this.computedSize == null) {
+      throw new Error('layout not yet computed')
+    }
+    this.entities.forEach(obj => obj.draw(renderer))
+  }
+}

--- a/src/diagram/parts/diagram-part.ts
+++ b/src/diagram/parts/diagram-part.ts
@@ -1,0 +1,17 @@
+import { Renderer } from '../../renderer/renderer'
+
+/**
+ * A diagram part is usually a complex visual element that includes dynamic content
+ * and requires specific layout information.
+ * How this is done depends on the type of diagram part.
+ *
+ * After a part has been laid out, it can be drawn to a rendering surface.
+ */
+export interface DiagramPart {
+  /**
+   * Draw this diagram part to the given renderer.
+   *
+   * @param renderer The renderer.
+   */
+  draw: (renderer: Renderer) => void
+}

--- a/src/diagram/parts/entity-diagram-part.ts
+++ b/src/diagram/parts/entity-diagram-part.ts
@@ -1,0 +1,76 @@
+import { Entity, EntityType } from '../../sequence/entity'
+import { LifelineDrawable } from '../drawables/lifeline-drawable'
+import { HeadDrawable } from '../drawables/head-drawable'
+import { ActorHeadDrawable } from '../drawables/actor-head-drawable'
+import { ComponentHeadDrawable } from '../drawables/component-head-drawable'
+import { RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+import { Point } from '../../util/geometry/point'
+import { DiagramPart } from './diagram-part'
+
+/**
+ * Create a head drawable for the given type of entity, configured with the given display name.
+ *
+ * @param type The entity type.
+ * @param name The name of the entity (visible on the head).
+ * @returns The type-specific head.
+ */
+function getHeadForType (type: EntityType, name: string): HeadDrawable {
+  return type === EntityType.ACTOR
+    ? new ActorHeadDrawable(name)
+    : new ComponentHeadDrawable(name)
+}
+
+/**
+ * A diagram part representing an entity (actor / component / ...).
+ */
+export class EntityDiagramPart implements DiagramPart {
+  readonly entity: Entity
+
+  private readonly drawable: LifelineDrawable
+  private topCenter: Point = Point.ORIGIN
+  private lifelineEndY: number = 0
+
+  constructor (entity: Entity) {
+    this.entity = entity
+    this.drawable = new LifelineDrawable(getHeadForType(entity.type, entity.name))
+  }
+
+  /**
+   * Measure the size of head for this entity.
+   *
+   * @param attr The rendering attributes.
+   * @returns The head size.
+   */
+  measureHead (attr: RenderAttributes): Size {
+    return this.drawable.measureHead(attr)
+  }
+
+  /**
+   * Set the position of this entity.
+   *
+   * The y coordinate determines the height below which the head (and, later, the lifeline line) appear.
+   * The x coordinate determines the center location of the lifeline.
+   *
+   * @param position The position.
+   */
+  setTopCenter (position: Point): void {
+    this.topCenter = position
+  }
+
+  /**
+   * Set the y coordinate at which the lifeline stops. This is an absolute coordinate,
+   * independent of the lifeline's anchor position.
+   *
+   * @param endHeight The absolute height at which the lifeline stops.
+   */
+  setLifelineEnd (endHeight: number): void {
+    this.lifelineEndY = endHeight
+  }
+
+  draw (renderer: Renderer): void {
+    this.drawable.setTopCenter(this.topCenter)
+    this.drawable.setEndHeight(this.lifelineEndY)
+    this.drawable.draw(renderer)
+  }
+}

--- a/test/diagram/diagram.test.ts
+++ b/test/diagram/diagram.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai'
+import { Diagram } from '../../src/diagram/diagram'
+import { Sequence } from '../../src/sequence/sequence'
+import { Renderer } from '../../src/renderer/renderer'
+import { Size } from '../../src/util/geometry/size'
+import { Entity, EntityType } from '../../src/sequence/entity'
+import { Point } from '../../src/util/geometry/point'
+
+describe('src/diagram/diagram.ts', function () {
+  describe('#layout()', function () {
+    it('enables size and draw methods', function () {
+      const diag = Diagram.create(new Sequence([], []))
+      const renderer: Renderer = {
+        measureText: () => Size.ZERO,
+        renderLine: () => {},
+        renderBox: () => {},
+        renderPath: () => {},
+        renderText: () => {}
+      }
+      diag.layout(renderer)
+      expect(() => diag.getComputedSize()).to.not.throw()
+      expect(() => diag.draw(renderer)).to.not.throw()
+    })
+  })
+
+  describe('#getComputedSize()', function () {
+    it('throws if layout was not called', function () {
+      const diag = Diagram.create(new Sequence([], []))
+      expect(() => diag.getComputedSize()).to.throw()
+    })
+  })
+
+  describe('#draw()', function () {
+    it('throws if layout was not called', function () {
+      const diag = Diagram.create(new Sequence([], []))
+      const renderer: Renderer = {
+        measureText: () => Size.ZERO,
+        renderLine: () => {},
+        renderBox: () => {},
+        renderPath: () => {},
+        renderText: () => {}
+      }
+      expect(() => diag.draw(renderer)).to.throw()
+    })
+
+    it('draws all entities in order, with distance between them', function (done) {
+      const names = ['foo', 'bar', 'baz']
+      const entities = names.map((name, i) => new Entity(EntityType.COMPONENT, `e${i}`, name))
+      const diag = Diagram.create(new Sequence(entities, []))
+      let prevX = 0
+      const renderer: Renderer = {
+        measureText: () => Size.ZERO,
+        renderLine: () => {},
+        renderBox: () => {},
+        renderPath: () => {},
+        renderText: (text: string, position: Point) => {
+          expect(text).to.equal(names.shift())
+          expect(position.x).to.be.greaterThan(prevX)
+          prevX = position.x + 30 // minimum 30 pixels between entities
+          if (names.length === 0) done()
+        }
+      }
+      diag.layout(renderer)
+      diag.draw(renderer)
+    })
+  })
+})

--- a/test/diagram/parts/entity-diagram-part.test.ts
+++ b/test/diagram/parts/entity-diagram-part.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai'
+
+import { EntityDiagramPart } from '../../../src/diagram/parts/entity-diagram-part'
+import { Entity, EntityType } from '../../../src/sequence/entity'
+import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Size } from '../../../src/util/geometry/size'
+import { Point } from '../../../src/util/geometry/point'
+
+describe('src/diagram/parts/entity-diagram-part.ts', function () {
+  describe('#measureHead()', function () {
+    it('measures differently depending on entity type', function () {
+      // this is not very exact, but it's better than nothing
+      const componentPart = new EntityDiagramPart(new Entity(EntityType.COMPONENT, 'id', 'name'))
+      const actorPart = new EntityDiagramPart(new Entity(EntityType.ACTOR, 'id', 'name'))
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      expect(componentPart.measureHead(attr)).to.not.deep.equal(actorPart.measureHead(attr))
+    })
+
+    it('measures differently depending on entity name', function () {
+      // this is not very exact, but it's better than nothing
+      const part1 = new EntityDiagramPart(new Entity(EntityType.COMPONENT, 'id', 'short'))
+      const part2 = new EntityDiagramPart(new Entity(EntityType.COMPONENT, 'id', 'very very very long name'))
+      const attr: RenderAttributes = {
+        measureText: (str, fontSize) => new Size(str.length * fontSize, fontSize)
+      }
+      expect(part2.measureHead(attr).width).to.be.greaterThan(part1.measureHead(attr).width)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('draws lifeline at correct position', function () {
+      const renderer: Renderer = {
+        measureText: () => Size.ZERO,
+        renderBox: () => {},
+        renderLine: (start, end) => {
+          expect(start.x).to.equal(150)
+          expect(start.y).to.be.greaterThan(200).and.lessThan(300)
+          expect(end.x).to.equal(150)
+          expect(end.y).to.equal(700)
+        },
+        renderPath: () => {},
+        renderText: () => {}
+      }
+      const part = new EntityDiagramPart(new Entity(EntityType.COMPONENT, 'id', 'name'))
+      part.setTopCenter(new Point(150, 200))
+      part.setLifelineEnd(700)
+      part.draw(renderer)
+    })
+  })
+})


### PR DESCRIPTION
This adds a `Diagram` class, a `DiagramPart` interface, and a `EntityDiagramPart` class (that represents a single entity visually).
The entities are laid out using the constraints layout, based on their dynamic size, and with a margin between them.