### PR TITLE
feat(diagram): Implement ActivationWalker

### DIFF
--- a/src/diagram/activation-walker.ts
+++ b/src/diagram/activation-walker.ts
@@ -1,0 +1,88 @@
+import { Activation } from '../sequence/activation'
+import { CountMap } from '../util/count-map'
+
+/**
+ * This class can be extended to enable any kind of action on the tree-like Activation data structure.
+ *
+ * Methods can be provided to execute on every node: one is called in pre-order, the other in post-order.
+ * In other words, the tree is iterated in natural order and one function is called before recursion,
+ * the other after recursion.
+ *
+ * Additionally, the walker takes care of counting activation levels.
+ * A level is the number of times a particular node was activated, i.e., visited during the walk.
+ * Sometimes, nodes should not become activated even when visited (for "create" messages, for example).
+ * For that purpose, a third method can be provided that decides whether to activate a node or not.
+ */
+export abstract class ActivationWalker<S> {
+  /**
+   * Perform a recursive walk on the given activation.
+   *
+   * @param root The activation.
+   */
+  walk (root: Activation): void {
+    this.walkRecursively(root, new CountMap())
+  }
+
+  private walkRecursively (node: Activation, levels: CountMap<string>): void {
+    // determine levels and potentially increment toLevel
+    const fromLevel = node.message.from != null ? levels.get(node.message.from.id) : 0
+    let activate = false
+    let toLevel = 0
+    if (node.message.to != null) {
+      activate = this.shouldActivate(node)
+      toLevel = activate ? levels.incrementAndGet(node.message.to.id) : 0
+    }
+
+    // pre -> (recurse) -> post
+    const state = this.pre(node, fromLevel, toLevel, activate)
+    node.children.forEach(child => this.walkRecursively(child, levels))
+    this.post(node, fromLevel, toLevel, state)
+
+    // if level was incremented, decrement it again
+    if (node.message.to != null && activate) {
+      levels.decrement(node.message.to.id)
+    }
+  }
+
+  /**
+   * Given a node, determine whether the message target should become activated.
+   *
+   * @param node The current node.
+   * @returns Whether the node should become activated.
+   * @protected
+   */
+  protected abstract shouldActivate (node: Activation): boolean
+
+  /**
+   * This method is called in pre-order traversal of the tree.
+   * In other words, this is the first thing that gets called for every node that is visited,
+   * before recursion and before the post-order method.
+   *
+   * Implementing classes can choose to compute some state object in this method.
+   * The state will be stored and passed on to the post-order method as soon as it is run.
+   *
+   * @param node The current node.
+   * @param fromLevel The number of activations the message source had when sending the message.
+   * @param toLevel The number of activations the message target now has due to the message; always 0 if not activated.
+   * @param active Whether the target was activated by the message.
+   * @returns The computed state.
+   * @protected
+   */
+  protected abstract pre (node: Activation, fromLevel: number, toLevel: number, active: boolean): S
+
+  /**
+   * This method is called in post-order traversal of the tree.
+   * In other words, this is the last thing that gets called for every node that is visited,
+   * after the pre-order method and after recursion.
+   *
+   * Implementing classes can choose to compute some state object in the pre-order method.
+   * This state is stored and passed as a parameter to this method.
+   *
+   * @param node The current node.
+   * @param fromLevel The number of activations the message source had when sending the message.
+   * @param toLevel The number of activations the message target now has due to the message; always 0 if not activated.
+   * @param state The state computed during pre-order traversal.
+   * @protected
+   */
+  protected abstract post (node: Activation, fromLevel: number, toLevel: number, state: S): void
+}

--- a/src/util/count-map.ts
+++ b/src/util/count-map.ts
@@ -1,0 +1,43 @@
+/**
+ * This data structure stores for each key a single number (the associated count).
+ * The count can be retrieved, incremented, and decremented.
+ * The count cannot reach values below 0.
+ */
+export class CountMap<K> {
+  private readonly counts: Map<K, number> = new Map()
+
+  /**
+   * Obtain the count for the given key.
+   *
+   * @param key The key.
+   * @returns The associated count.
+   */
+  get (key: K): number {
+    return this.counts.get(key) ?? 0
+  }
+
+  /**
+   * Increment the count for the given key by one.
+   *
+   * @param key The key.
+   * @returns The associated count after incrementing.
+   */
+  incrementAndGet (key: K): number {
+    const count = this.get(key) + 1
+    this.counts.set(key, count)
+    return count
+  }
+
+  /**
+   * Decrement the count for the given key by one.
+   *
+   * @param key The key.
+   */
+  decrement (key: K): void {
+    const count = this.get(key)
+    if (count <= 0) {
+      throw new Error('unexpected decrement of count=0')
+    }
+    this.counts.set(key, count - 1)
+  }
+}

--- a/test/diagram/activation-walker.test.ts
+++ b/test/diagram/activation-walker.test.ts
@@ -1,0 +1,186 @@
+import { expect } from 'chai'
+
+import { ActivationWalker } from '../../src/diagram/activation-walker'
+import { Activation } from '../../src/sequence/activation'
+import { Entity, EntityType } from '../../src/sequence/entity'
+import { LostMessage, SyncMessage } from '../../src/sequence/message'
+
+interface MockWalkerConfig {
+  shouldActivate?: (node: Activation) => boolean
+  pre?: (node: Activation, fromLevel: number, toLevel: number, active: boolean) => any
+  post?: (node: Activation, fromLevel: number, toLevel: number, state: any) => void
+}
+
+class MockWalker extends ActivationWalker<any> {
+  constructor (
+    private readonly config: MockWalkerConfig
+  ) {
+    super()
+  }
+
+  protected override shouldActivate (node: Activation): boolean {
+    return this.config.shouldActivate != null ? this.config.shouldActivate(node) : false
+  }
+
+  protected override pre (node: Activation, fromLevel: number, toLevel: number, active: boolean): any {
+    return this.config.pre != null ? this.config.pre(node, fromLevel, toLevel, active) : undefined
+  }
+
+  protected override post (node: Activation, fromLevel: number, toLevel: number, state: any): void {
+    if (this.config.post != null) {
+      this.config.post(node, fromLevel, toLevel, state)
+    }
+  }
+}
+
+describe('src/diagram/activation-walker.ts', function () {
+  const foo = new Entity(EntityType.COMPONENT, 'foo', 'Foo')
+  const bar = new Entity(EntityType.COMPONENT, 'bar', 'Bar')
+
+  // helper method for construction of activation trees
+  function act (label: string, ...children: Activation[]): Activation {
+    return new Activation(new SyncMessage(foo, bar, label), undefined, children)
+  }
+
+  it('calls #pre() in pre-order, #post() in post-order', function () {
+    const preOrder: string[] = []
+    const postOrder: string[] = []
+    const walker = new MockWalker({
+      pre (node) {
+        preOrder.push(node.message.label)
+      },
+      post (node) {
+        postOrder.push(node.message.label)
+      }
+    })
+    const activation = (
+      act('a',
+        act('b',
+          act('c')),
+        act('d'),
+        act('e'))
+    )
+    walker.walk(activation)
+    expect(preOrder).to.deep.equal(['a', 'b', 'c', 'd', 'e'])
+    expect(postOrder).to.deep.equal(['c', 'b', 'd', 'e', 'a'])
+  })
+
+  it('passes state from pre to post', function () {
+    const states: Record<string, number> = {
+      a: 10,
+      b: 20,
+      c: 30,
+      d: 40
+    }
+    const walker = new MockWalker({
+      pre (node) {
+        return states[node.message.label]
+      },
+      post (node, fromLevel, toLevel, state) {
+        expect(state).to.equal(states[node.message.label])
+      }
+    })
+    const activation = (
+      act('a',
+        act('b',
+          act('c')),
+        act('d'))
+    )
+    walker.walk(activation)
+  })
+
+  it('uses fromLevel=0 and toLevel=0 if nothing ever activates', function () {
+    const walker = new MockWalker({
+      pre (node, fromLevel, toLevel) {
+        expect(fromLevel).to.equal(0)
+        expect(toLevel).to.equal(0)
+      },
+      post (node, fromLevel, toLevel) {
+        expect(fromLevel).to.equal(0)
+        expect(toLevel).to.equal(0)
+      }
+    })
+    const activation = (
+      act('a',
+        act('b',
+          act('c')),
+        act('d'))
+    )
+    walker.walk(activation)
+  })
+
+  it('uses fromLevel prior to activation, toLevel after activation for self-calls', function () {
+    const walker = new MockWalker({
+      shouldActivate () {
+        return true
+      },
+      pre (node, fromLevel, toLevel) {
+        const level = parseInt(node.message.label)
+        expect(fromLevel).to.equal(level)
+        expect(toLevel).to.equal(level + 1)
+      },
+      post (node, fromLevel, toLevel) {
+        const level = parseInt(node.message.label)
+        expect(fromLevel).to.equal(level)
+        expect(toLevel).to.equal(level + 1)
+      }
+    })
+
+    const activation = new Activation(new SyncMessage(foo, foo, '0'), undefined, [
+      new Activation(new SyncMessage(foo, foo, '1'), undefined, [])
+    ])
+    walker.walk(activation)
+  })
+
+  it('calculates levels correctly between 2 participants', function () {
+    const expectedLevels: Record<string, number[]> = {
+      0: [0, 1],
+      1: [1, 0],
+      2: [0, 2]
+    }
+    const walker = new MockWalker({
+      shouldActivate (node) {
+        return node.message.label === '0' || node.message.label === '2'
+      },
+      pre (node, fromLevel, toLevel) {
+        expect(fromLevel).to.equal(expectedLevels[node.message.label][0])
+        expect(toLevel).to.equal(expectedLevels[node.message.label][1])
+      },
+      post (node, fromLevel, toLevel) {
+        expect(fromLevel).to.equal(expectedLevels[node.message.label][0])
+        expect(toLevel).to.equal(expectedLevels[node.message.label][1])
+      }
+    })
+
+    const activation = new Activation(new SyncMessage(foo, bar, '0'), undefined, [
+      new Activation(new SyncMessage(bar, foo, '1'), undefined, [
+        new Activation(new SyncMessage(foo, bar, '2'), undefined, [])
+      ])
+    ])
+    walker.walk(activation)
+  })
+
+  it('never activates without message target', function () {
+    const walker = new MockWalker({
+      shouldActivate (node) {
+        expect(node.message.to).to.be.oneOf([foo, bar])
+        return true
+      },
+      pre (node, fromLevel, toLevel) {
+        if (node.message.to != null) {
+          expect(toLevel).to.be.greaterThan(0)
+        } else {
+          expect(toLevel).to.equal(0)
+        }
+      }
+    })
+
+    const activation = new Activation(new SyncMessage(foo, bar, '0'), undefined, [
+      new Activation(new SyncMessage(bar, foo, '1'), undefined, [
+        new Activation(new LostMessage(foo, '2'), undefined, [])
+      ]),
+      new Activation(new LostMessage(bar, '3'), undefined, [])
+    ])
+    walker.walk(activation)
+  })
+})

--- a/test/diagram/diagram.test.ts
+++ b/test/diagram/diagram.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+
 import { Diagram } from '../../src/diagram/diagram'
 import { Sequence } from '../../src/sequence/sequence'
 import { Renderer } from '../../src/renderer/renderer'

--- a/test/util/count-map.test.ts
+++ b/test/util/count-map.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+
+import { CountMap } from '../../src/util/count-map'
+
+describe('src/util/count-map.ts', function () {
+  it('returns 0 by default', function () {
+    expect(new CountMap<string>().get('foo')).to.equal(0)
+    expect(new CountMap<string>().get('bar')).to.equal(0)
+  })
+
+  it('can increment', function () {
+    const map = new CountMap<string>()
+    expect(map.incrementAndGet('foo')).to.equal(1)
+    expect(map.incrementAndGet('foo')).to.equal(2)
+    expect(map.incrementAndGet('foo')).to.equal(3)
+  })
+
+  it('can decrement', function () {
+    const map = new CountMap<string>()
+    expect(map.incrementAndGet('foo')).to.equal(1)
+    expect(map.incrementAndGet('foo')).to.equal(2)
+    map.decrement('foo')
+    expect(map.get('foo')).to.equal(1)
+    map.decrement('foo')
+    expect(map.get('foo')).to.equal(0)
+  })
+
+  it('throws when decrementing value that was never incremented', function () {
+    const map = new CountMap<string>()
+    expect(() => map.decrement('foo')).to.throw()
+  })
+
+  it('throws when decrementing too often', function () {
+    const map = new CountMap<string>()
+    map.incrementAndGet('foo')
+    map.incrementAndGet('foo')
+    map.decrement('foo')
+    map.decrement('foo')
+    expect(() => map.decrement('foo')).to.throw()
+  })
+})


### PR DESCRIPTION
Implements a recursive iterator over activation-trees that is capable of counting activation levels and can call pre-order as well as post-order methods.

This will be useful for diagram construction.