### PR TITLE
feat(renderer): Implement polylines with end markers (message arrows)

### DIFF
--- a/src/renderer/browser-svg/svg-dom.ts
+++ b/src/renderer/browser-svg/svg-dom.ts
@@ -1,0 +1,26 @@
+export type AttributeValue = string | number | undefined
+
+/**
+ * Create an XML element for the SVG namespace.
+ *
+ * @param tagName The tag name for the element to create.
+ * @returns The created element.
+ */
+export function createSvgElement (tagName: string): SVGElement {
+  return document.createElementNS('http://www.w3.org/2000/svg', tagName)
+}
+
+/**
+ * Apply a set of attributes to the given element.
+ * The attribute values (when present) will be converted to strings.
+ *
+ * @param element The SVG element.
+ * @param attrs The attributes to apply.
+ */
+export function applyAttributes (element: SVGElement, attrs: Record<string, AttributeValue>): void {
+  for (const key of Object.keys(attrs)) {
+    const value = attrs[key]
+    if (value == null) continue
+    element.setAttribute(key, String(value))
+  }
+}

--- a/src/renderer/browser-svg/svg-marker-manager.ts
+++ b/src/renderer/browser-svg/svg-marker-manager.ts
@@ -1,0 +1,105 @@
+import { LineMarker } from '../renderer'
+import { applyAttributes, createSvgElement } from './svg-dom'
+
+/**
+ * Specifies a marker id, whether to fill and/or stroke the marker path, and the marker path data.
+ */
+interface MarkerDefinition {
+  id: string
+  fill: boolean
+  stroke: boolean
+  pathData: string
+}
+
+const MARKERS: ReadonlyMap<LineMarker, Readonly<MarkerDefinition>> = new Map([
+  [LineMarker.ARROW_OPEN, {
+    id: 'lmao',
+    fill: false,
+    stroke: true,
+    pathData: 'M-12,-6 L0,0 L-12,6'
+  }],
+  [LineMarker.ARROW_FULL, {
+    id: 'lmaf',
+    fill: true,
+    stroke: false,
+    pathData: 'M-12,-6 L0,0 L-12,6 Z'
+  }],
+  [LineMarker.CIRCLE_FULL, {
+    id: 'lmcf',
+    fill: true,
+    stroke: false,
+    pathData: 'M-6,0 A6,6 0 1 0 6,0 M-6,0 A6,6 0 1 1 6,0'
+  }],
+  [LineMarker.ARROW_INTO_CIRCLE_FULL, {
+    id: 'lmaicf',
+    fill: true,
+    stroke: false,
+    pathData: 'M-18,-6 L-6,0 L-18,6 Z M-6,0 A6,6 0 1 0 6,0 M-6,0 A6,6 0 1 1 6,0'
+  }]
+])
+
+/**
+ * Build an SVG element from the given marker definition.
+ *
+ * @param def The marker definition.
+ * @param color The color the marker should have.
+ * @returns The created marker.
+ */
+function buildMarker (def: MarkerDefinition, color: string): SVGMarkerElement {
+  const marker = createSvgElement('marker') as SVGMarkerElement
+  applyAttributes(marker, {
+    id: def.id,
+    viewBox: '-18 -6 30 12',
+    refX: 0,
+    refY: 0,
+    markerUnits: 'userSpaceOnUse',
+    markerWidth: 30,
+    markerHeight: 12,
+    orient: 'auto'
+  })
+  const path = createSvgElement('path')
+  applyAttributes(path, {
+    d: def.pathData,
+    fill: def.fill ? color : 'none',
+    stroke: def.stroke ? color : 'none',
+    'stroke-width': def.stroke ? 2 : 0
+  })
+  marker.appendChild(path)
+  return marker
+}
+
+/**
+ * This class allows SVG markers to be created lazily and applied to the SVG document's defs tag on-demand.
+ */
+export class SvgMarkerManager {
+  private readonly defs: SVGDefsElement
+  private readonly markerColor: string
+
+  private readonly created: Set<LineMarker> = new Set()
+
+  constructor (defs: SVGDefsElement, markerColor: string) {
+    this.defs = defs
+    this.markerColor = markerColor
+  }
+
+  /**
+   * Obtain a reference string to a marker, that can be used in marker-start and marker-end attributes.
+   * If this is the first time the marker is used, it will be added to the SVG's defs tag.
+   *
+   * The result might be undefined if no marker definition exists for the given type of marker.
+   *
+   * @param marker The type of marker to reference.
+   * @returns A reference to the marker, or undefined if no marker exists for this type.
+   */
+  referenceMarker (marker: LineMarker): string | undefined {
+    const def = MARKERS.get(marker)
+    if (def == null) {
+      return undefined
+    }
+    if (!this.created.has(marker)) {
+      this.defs.appendChild(buildMarker(def, this.markerColor))
+      this.created.add(marker)
+    }
+    return `url(#${def.id})`
+  }
+}

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -2,6 +2,17 @@ import { Size } from '../util/geometry/size'
 import { Point } from '../util/geometry/point'
 
 /**
+ * Represents markers that can be applied to the ends of lines.
+ */
+export enum LineMarker {
+  NONE,
+  ARROW_FULL,
+  ARROW_OPEN,
+  CIRCLE_FULL,
+  ARROW_INTO_CIRCLE_FULL
+}
+
+/**
  * This interface defines how stroke should be applied to a shape when rendering.
  */
 export interface StrokeOptions {
@@ -47,6 +58,16 @@ export interface Renderer extends RenderAttributes {
   renderLine: (start: Point, end: Point, options?: StrokeOptions) => void
 
   /**
+   * Render a polyline, potentially with markers at the end, useful for arrows.
+   *
+   * @param points The points of the polyline (first point, [intermediate points, ..., ], last point).
+   * @param end1 The marker to place at the first point.
+   * @param end2 The marker to place at the last point.
+   * @param options Options for stroking the path. If not provided, sensible defaults will be used.
+   */
+  renderPolyline: (points: Point[], end1: LineMarker, end2: LineMarker, options?: StrokeOptions) => void
+
+  /**
    * Render a path (SVG path data format).
    * The path coordinates are shifted by the given offset (offset added to path coordinates).
    *
@@ -60,7 +81,7 @@ export interface Renderer extends RenderAttributes {
    * Render a text at the given position.
    *
    * @param text The text to render.
-   * @param offset The starting coordinate (beginning of line, baseline height).
+   * @param position The starting coordinate (beginning of line, baseline height).
    * @param fontSize The font size (in pixels) to use for rendering.
    */
   renderText: (text: string, position: Point, fontSize: number) => void


### PR DESCRIPTION
This adds a method renderPolyline to the Renderer interface.
Line start and end markers can be specified.
A "marker manager" is implemented for the SVG renderer that lazily builds marker definitions.