### PR TITLE
feat(diagram): Implement more alignments for TextDrawable

### DIFF
--- a/src/diagram/drawables/actor-head-drawable.ts
+++ b/src/diagram/drawables/actor-head-drawable.ts
@@ -1,9 +1,14 @@
 import { HeadDrawable } from './head-drawable'
-import { TextAlignment, TextDrawable } from './text-drawable'
+import { HorizontalTextAlignment, TextAlignment, TextDrawable, VerticalTextAlignment } from './text-drawable'
 import { StickFigureDrawable } from './stick-figure-drawable'
 import { Point } from '../../util/geometry/point'
 import { RenderAttributes, Renderer } from '../../renderer/renderer'
 import { Size } from '../../util/geometry/size'
+
+const TEXT_ALIGN: TextAlignment = {
+  h: HorizontalTextAlignment.CENTER,
+  v: VerticalTextAlignment.BELOW
+}
 
 /**
  * An entity head Drawable for entities of type "Actor".
@@ -40,7 +45,7 @@ export class ActorHeadDrawable implements HeadDrawable {
     const figureSize = this.figure.measure(renderer)
 
     this.figure.setTopCenter(this.topCenter)
-    this.text.setPosition(this.topCenter.translate(0, figureSize.height), TextAlignment.CENTER_BELOW)
+    this.text.setPosition(this.topCenter.translate(0, figureSize.height), TEXT_ALIGN)
 
     this.figure.draw(renderer)
     this.text.draw(renderer)

--- a/src/diagram/drawables/component-head-drawable.ts
+++ b/src/diagram/drawables/component-head-drawable.ts
@@ -1,10 +1,15 @@
 import { HeadDrawable } from './head-drawable'
-import { TextAlignment, TextDrawable } from './text-drawable'
+import { HorizontalTextAlignment, TextAlignment, TextDrawable, VerticalTextAlignment } from './text-drawable'
 import { Point } from '../../util/geometry/point'
 import { RenderAttributes, Renderer } from '../../renderer/renderer'
 import { Size } from '../../util/geometry/size'
 import { BoxDrawable } from './box-drawable'
 import { COMPONENT_HEAD_PADDING_H, COMPONENT_HEAD_PADDING_V } from '../config'
+
+const TEXT_ALIGN: TextAlignment = {
+  h: HorizontalTextAlignment.CENTER,
+  v: VerticalTextAlignment.MIDDLE
+}
 
 /**
  * An entity head Drawable for entities of type "Component".
@@ -36,7 +41,7 @@ export class ComponentHeadDrawable implements HeadDrawable {
     this.box.setSize(size)
 
     const boxCenter = this.topCenter.translate(0, size.height / 2)
-    this.text.setPosition(boxCenter, TextAlignment.CENTER_CENTER)
+    this.text.setPosition(boxCenter, TEXT_ALIGN)
 
     this.box.draw(renderer)
     this.text.draw(renderer)

--- a/test/diagram/drawables/text-drawable.test.ts
+++ b/test/diagram/drawables/text-drawable.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai'
 
-import { TextAlignment, TextDrawable } from '../../../src/diagram/drawables/text-drawable'
+import {
+  HorizontalTextAlignment,
+  TextAlignment,
+  TextDrawable,
+  VerticalTextAlignment
+} from '../../../src/diagram/drawables/text-drawable'
 import { Size } from '../../../src/util/geometry/size'
 import { RenderAttributes, Renderer } from '../../../src/renderer/renderer'
 import { Point } from '../../../src/util/geometry/point'
@@ -63,9 +68,15 @@ describe('src/diagram/drawables/text-drawable.ts', function () {
         obj.setPosition(new Point(50, 100), align)
         obj.draw(renderer)
       }
-      check(TextAlignment.CENTER_CENTER, new Point(30, 107.5))
-      check(TextAlignment.CENTER_ABOVE, new Point(30, 100))
-      check(TextAlignment.CENTER_BELOW, new Point(30, 115))
+      check({ h: HorizontalTextAlignment.CENTER, v: VerticalTextAlignment.MIDDLE }, new Point(30, 107.5))
+      check({ h: HorizontalTextAlignment.CENTER, v: VerticalTextAlignment.ABOVE }, new Point(30, 100))
+      check({ h: HorizontalTextAlignment.CENTER, v: VerticalTextAlignment.BELOW }, new Point(30, 115))
+      check({ h: HorizontalTextAlignment.LEFT, v: VerticalTextAlignment.MIDDLE }, new Point(10, 107.5))
+      check({ h: HorizontalTextAlignment.LEFT, v: VerticalTextAlignment.ABOVE }, new Point(10, 100))
+      check({ h: HorizontalTextAlignment.LEFT, v: VerticalTextAlignment.BELOW }, new Point(10, 115))
+      check({ h: HorizontalTextAlignment.RIGHT, v: VerticalTextAlignment.MIDDLE }, new Point(50, 107.5))
+      check({ h: HorizontalTextAlignment.RIGHT, v: VerticalTextAlignment.ABOVE }, new Point(50, 100))
+      check({ h: HorizontalTextAlignment.RIGHT, v: VerticalTextAlignment.BELOW }, new Point(50, 115))
     })
   })
 })


### PR DESCRIPTION
TextDrawable can now align text to the left, right, or centered around a given point.
All three vertical positions (above, below, middle) can be combined with any of the horizontal positions.