### PR TITLE
feat(diagram): Implement ArrowDrawable

### DIFF
--- a/src/diagram/config.ts
+++ b/src/diagram/config.ts
@@ -5,5 +5,6 @@ export const COMPONENT_HEAD_PADDING_V = 12
 
 export const FONT_SIZE = 16
 export const LINE_WIDTH_LIFELINES = 1
+export const LINE_WIDTH_ARROWS = 2
 
 export const ACTIVATION_THICKNESS = 15

--- a/src/diagram/drawables/arrow-drawable.ts
+++ b/src/diagram/drawables/arrow-drawable.ts
@@ -1,0 +1,136 @@
+import { Drawable } from './drawable'
+import { HorizontalTextAlignment, TextAlignment, TextDrawable, VerticalTextAlignment } from './text-drawable'
+import { Point } from '../../util/geometry/point'
+import { BoundingBox } from '../../util/geometry/bounding-box'
+import { LineMarker, RenderAttributes, Renderer } from '../../renderer/renderer'
+import { Size } from '../../util/geometry/size'
+import { LINE_WIDTH_ARROWS } from '../config'
+
+/**
+ * Compute horizontal label position depending on the arrow's bounding box and text alignment.
+ *
+ * @param bb The bounding box computed for the arrow's polyline.
+ * @param hAlign The required horizontal label alignment.
+ * @param spacing The amount of spacing to keep between the arrow and the text.
+ * @returns The text x coordinate.
+ */
+function getLabelX (bb: BoundingBox, hAlign: HorizontalTextAlignment, spacing: number): number {
+  switch (hAlign) {
+    case HorizontalTextAlignment.LEFT:
+      return bb.minX - spacing
+    case HorizontalTextAlignment.CENTER:
+      return bb.centerX()
+    case HorizontalTextAlignment.RIGHT:
+      return bb.maxX + spacing
+  }
+}
+
+/**
+ * Compute vertical label position depending on the arrow's bounding box and text alignment.
+ *
+ * @param bb The bounding box computed for the arrow's polyline.
+ * @param vAlign The required vertical label alignment.
+ * @param spacing The amount of spacing to keep between the arrow and the text.
+ * @returns The text y coordinate.
+ */
+function getLabelY (bb: BoundingBox, vAlign: VerticalTextAlignment, spacing: number): number {
+  switch (vAlign) {
+    case VerticalTextAlignment.ABOVE:
+      return bb.centerY() - spacing
+    case VerticalTextAlignment.MIDDLE:
+      return bb.centerY()
+    case VerticalTextAlignment.BELOW:
+      return bb.centerY() + spacing
+  }
+}
+
+/**
+ * Compute the overall label position depending on the arrow's bounding box and text alignment.
+ *
+ * @param bb The bounding box computed for the arrow's polyline.
+ * @param align The text alignment specifier.
+ * @returns The text coordinates.
+ */
+function getLabelPositionForAlignment (bb: BoundingBox, align: TextAlignment): Point {
+  const spacing = 6
+  const x = getLabelX(bb, align.h, spacing)
+  const y = getLabelY(bb, align.v, spacing)
+  return new Point(x, y)
+}
+
+/**
+ * A drawable for labelled arrows, such as those used for sequence messages.
+ * The arrow is defined via polyline (array of points). Markers can be customized for each line end.
+ * The arrow can also be drawn with a dashed line.
+ */
+export class ArrowDrawable implements Drawable {
+  private readonly labelDrawable: TextDrawable | undefined
+  private readonly markerStart: LineMarker
+  private readonly markerEnd: LineMarker
+  private readonly dashed: boolean
+
+  private points: Point[] = []
+  private textAlign: TextAlignment = { h: HorizontalTextAlignment.CENTER, v: VerticalTextAlignment.ABOVE }
+
+  constructor (label: string, markerStart: LineMarker, markerEnd: LineMarker, dashed: boolean) {
+    const trimmedLabel = label.trim()
+
+    this.labelDrawable = trimmedLabel.length > 0 ? new TextDrawable(trimmedLabel) : undefined
+    this.markerStart = markerStart
+    this.markerEnd = markerEnd
+    this.dashed = dashed
+  }
+
+  /**
+   * Set the points array (polyline path) to use for drawing this arrow.
+   *
+   * @param points The points making up the arrow line.
+   */
+  setPoints (points: Point[]): void {
+    this.points = points
+  }
+
+  /**
+   * Set the alignment for the arrow label.
+   *
+   * @param align The text alignment.
+   */
+  setLabelAlignment (align: TextAlignment): void {
+    this.textAlign = align
+  }
+
+  private getBoundingBox (): BoundingBox {
+    return BoundingBox.containingPoints(this.points)
+  }
+
+  /**
+   * Compute the label dimensions (ignoring arrow points completely).
+   *
+   * @param attr The rendering attributes.
+   * @returns The measured size of the label.
+   */
+  measureLabel (attr: RenderAttributes): Size {
+    return this.labelDrawable?.measure(attr) ?? Size.ZERO
+  }
+
+  measure (_attr: RenderAttributes): Size {
+    return this.getBoundingBox().size()
+  }
+
+  draw (renderer: Renderer): void {
+    if (this.points.length < 2) {
+      return
+    }
+
+    renderer.renderPolyline(this.points, this.markerStart, this.markerEnd, {
+      lineWidth: LINE_WIDTH_ARROWS,
+      dashed: this.dashed
+    })
+
+    if (this.labelDrawable != null) {
+      const labelPos = getLabelPositionForAlignment(this.getBoundingBox(), this.textAlign)
+      this.labelDrawable.setPosition(labelPos, this.textAlign)
+      this.labelDrawable.draw(renderer)
+    }
+  }
+}

--- a/test/diagram/drawables/arrow-drawable.test.ts
+++ b/test/diagram/drawables/arrow-drawable.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai'
+
+import { ArrowDrawable } from '../../../src/diagram/drawables/arrow-drawable'
+import { Size } from '../../../src/util/geometry/size'
+import { LineMarker, RenderAttributes, Renderer } from '../../../src/renderer/renderer'
+import { Point } from '../../../src/util/geometry/point'
+
+describe('src/diagram/drawables/arrow-drawable.ts', function () {
+  describe('#measure()', function () {
+    it('returns size of polyline area', function () {
+      const attr: RenderAttributes = {
+        measureText: () => Size.ZERO
+      }
+      const obj = new ArrowDrawable('', LineMarker.NONE, LineMarker.NONE, false)
+      obj.setPoints([
+        new Point(100, 50),
+        new Point(200, 50),
+        new Point(200, 150),
+        new Point(100, 170)
+      ])
+      expect(obj.measure(attr)).to.deep.equal(new Size(100, 120))
+    })
+  })
+
+  describe('#measureLabel()', function () {
+    it('returns size of label text', function () {
+      const size = new Size(42, 37)
+      const attr: RenderAttributes = {
+        measureText: (text) => {
+          expect(text).to.equal('hello world')
+          return size
+        }
+      }
+      const obj = new ArrowDrawable('hello world', LineMarker.NONE, LineMarker.NONE, false)
+      expect(obj.measureLabel(attr)).to.deep.equal(size)
+    })
+
+    it('returns 0 for empty string', function () {
+      const attr: RenderAttributes = {
+        measureText: () => new Size(42, 37)
+      }
+      const obj = new ArrowDrawable('', LineMarker.NONE, LineMarker.NONE, false)
+      expect(obj.measureLabel(attr)).to.deep.equal(Size.ZERO)
+    })
+  })
+
+  describe('#draw()', function () {
+    it('renders polyline with defined points and markers', function (done) {
+      const expectedPoints = [
+        new Point(100, 50),
+        new Point(200, 50),
+        new Point(200, 150),
+        new Point(100, 170)
+      ]
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPolyline: (points, end1, end2, stroke) => {
+          expect(points).to.deep.equal(expectedPoints)
+          expect(end1).to.equal(LineMarker.ARROW_FULL)
+          expect(end2).to.equal(LineMarker.CIRCLE_FULL)
+          expect(stroke?.dashed).to.be.false
+          done()
+        },
+        renderPath: () => expect.fail(),
+        renderText: () => {},
+        measureText: () => Size.ZERO
+      }
+      const obj = new ArrowDrawable('foo', LineMarker.ARROW_FULL, LineMarker.CIRCLE_FULL, false)
+      obj.setPoints(expectedPoints)
+      obj.draw(renderer)
+    })
+
+    it('renders text', function (done) {
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPolyline: () => {},
+        renderPath: () => expect.fail(),
+        renderText: (text, position, fontSize) => {
+          expect(text).to.equal('hello world')
+          expect(position.x).to.equal(150)
+          expect(position.y).to.be.lessThan(50)
+          expect(fontSize).to.be.greaterThan(0)
+          done()
+        },
+        measureText: () => Size.ZERO
+      }
+      const obj = new ArrowDrawable('hello world', LineMarker.NONE, LineMarker.NONE, false)
+      obj.setPoints([
+        new Point(100, 50),
+        new Point(200, 50)
+      ])
+      obj.draw(renderer)
+    })
+
+    it('renders dashed if configured', function (done) {
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPolyline: (points, end1, end2, stroke) => {
+          expect(stroke?.dashed).to.be.true
+          done()
+        },
+        renderPath: () => expect.fail(),
+        renderText: () => {},
+        measureText: () => Size.ZERO
+      }
+      const obj = new ArrowDrawable('foo', LineMarker.NONE, LineMarker.NONE, true)
+      obj.setPoints([
+        new Point(100, 50),
+        new Point(200, 50)
+      ])
+      obj.draw(renderer)
+    })
+
+    it('does not render if no points specified', function () {
+      const renderer: Renderer = {
+        renderBox: () => expect.fail(),
+        renderLine: () => expect.fail(),
+        renderPolyline: () => expect.fail(),
+        renderPath: () => expect.fail(),
+        renderText: () => expect.fail(),
+        measureText: () => Size.ZERO
+      }
+      const obj = new ArrowDrawable('foo', LineMarker.ARROW_FULL, LineMarker.CIRCLE_FULL, false)
+      obj.draw(renderer)
+    })
+  })
+})


### PR DESCRIPTION
This adds a Drawable that can be used to draw labelled arrows with customizable end markers.
The class will be useful of course for drawing sequence messages.